### PR TITLE
 lemurbldr: Change directory structure on how RPMS are copied to DestDir

### DIFF
--- a/lemurbldr/cmd/clone_test.go
+++ b/lemurbldr/cmd/clone_test.go
@@ -32,8 +32,8 @@ func testClone(t *testing.T, force bool, quiet bool, workingDir string,
 
 	cmdErr := testutil.RunCmd(t, rootCmd, args, quiet, expectSuccess)
 	if expectSuccess {
-		dstPath := filepath.Join(workingDir, pkg)
-		assert.DirExists(t, dstPath)
+		destPath := filepath.Join(workingDir, pkg)
+		assert.DirExists(t, destPath)
 	} else {
 		t.Log("Expecting failure.")
 		assert.ErrorContains(t, cmdErr, expectedErr)

--- a/lemurbldr/impl/clone.go
+++ b/lemurbldr/impl/clone.go
@@ -10,9 +10,9 @@ import (
 	"lemurbldr/util"
 )
 
-// Clone git clones the repository pointed by repoURL to a new directory under
-// named by pkg under dstBasePath. force indicates whether to overwrite an
-// existing directory
+// Clone git clones the repository pointed by repoURL to a new directory
+// named repo under SrcDir.
+// force indicates it is okay to overwrite an existing directory
 func Clone(repoURL string, repo string, force bool) error {
 	if err := CheckEnv(); err != nil {
 		return err

--- a/lemurbldr/impl/createSrpm.go
+++ b/lemurbldr/impl/createSrpm.go
@@ -5,6 +5,7 @@ package impl
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -124,12 +125,20 @@ func createSrpm(repo string, pkgSpec manifest.Package) error {
 	errPrefix := util.ErrPrefix(fmt.Sprintf("impl.createSrpm(%s): ", pkg))
 
 	// These should be cleaned up and re-created
-	pkgSrpmsDestDir := getPkgSrpmsDestDir(pkg)
 	pkgWorkingDir := getPkgWorkingDir(pkg)
 	downloadDir := getDownloadDir(pkg)
-	setupDirs := []string{pkgWorkingDir, pkgSrpmsDestDir, downloadDir}
+	setupDirs := []string{pkgWorkingDir, downloadDir}
 	if err := util.CreateDirs(setupDirs, true, errPrefix); err != nil {
 		return err
+	}
+
+	// This should be cleaned up, but creation happens later
+	pkgSrpmsDestDir := getPkgSrpmsDestDir(pkg)
+	for _, dir := range []string{pkgSrpmsDestDir} {
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("%sError '%s' removing %s",
+				errPrefix, err, dir)
+		}
 	}
 
 	// First download the upstream source file (distro-SRPM/tarball)

--- a/lemurbldr/impl/mock.go
+++ b/lemurbldr/impl/mock.go
@@ -35,19 +35,23 @@ func fedoraMock(pkg string, arch string, srpmPath string) error {
 }
 
 // filterAndCopy copies files from srcDirPath to a specified
-// dstDirPath depending on filename.
-// movePathMap is a map from dstDirPath to regex.
+// destDirPath depending on filename.
+// movePathMap is a map from destDirPath to regex.
 // We walk through all files in srcDirPath and see if any regex in the map matches.
-// If it matches, files are moved to the dstDirPath corresponding to the regex.
-// dstDirPath is created if it doesn't exist.
+// If it matches, files are moved to the destDirPath corresponding to the regex.
+// destDirPath is created if it doesn't exist.
 func filterAndCopy(movePathMap map[string]string, srcDirPath string,
 	errPrefix util.ErrPrefix) error {
-	for dstDirPath, regexStr := range movePathMap {
+	for destDirPath, regexStr := range movePathMap {
 		filenames, gmfdErr := util.GetMatchingFilenamesFromDir(srcDirPath, regexStr, errPrefix)
 		if gmfdErr != nil {
 			return gmfdErr
 		}
-		if err := util.CopyFilesToDir(filenames, srcDirPath, dstDirPath, true, errPrefix); err != nil {
+		if err := util.RunSystemCmd("mkdir", "-p", destDirPath); err != nil {
+			return fmt.Errorf("%sError '%s' trying to create directory %s with prefixes",
+				errPrefix, err, destDirPath)
+		}
+		if err := util.CopyFilesToDir(filenames, srcDirPath, destDirPath, true, errPrefix); err != nil {
 			return err
 		}
 	}

--- a/lemurbldr/impl/mockCfg.go
+++ b/lemurbldr/impl/mockCfg.go
@@ -22,9 +22,10 @@ type MockCfgTemplateData struct {
 // This sets up the MockCfgTemplateData instance
 // for executing the template.
 // It also copies over any include files to the relevant directory.
-func setupTemplateData(errPrefix string,
+func setupTemplateData(
 	repo string, pkg string, arch string,
-	targetSpec manifest.Target) (
+	targetSpec manifest.Target,
+	errPrefix util.ErrPrefix) (
 	MockCfgTemplateData, error) {
 
 	var templateData MockCfgTemplateData
@@ -50,8 +51,7 @@ func setupTemplateData(errPrefix string,
 				fmt.Errorf("%sCannot find the include file specified in manifest %s", errPrefix, includeFileSrcPath)
 		}
 
-		if err := util.CopyFile(errPrefix,
-			includeFileSrcPath, mockCfgDir); err != nil {
+		if err := util.CopyFile(includeFileSrcPath, mockCfgDir, errPrefix); err != nil {
 			return MockCfgTemplateData{}, err
 		}
 
@@ -64,7 +64,7 @@ func setupTemplateData(errPrefix string,
 func createMockCfgFile(repo string, pkgSpec manifest.Package, arch string) error {
 	pkg := pkgSpec.Name
 
-	errPrefix := fmt.Sprintf("impl.createMockCfgFile(%s): ", pkg)
+	errPrefix := util.ErrPrefix(fmt.Sprintf("impl.createMockCfgFile(%s): ", pkg))
 
 	targetValid := false
 	var targetSpec manifest.Target
@@ -76,8 +76,7 @@ func createMockCfgFile(repo string, pkgSpec manifest.Package, arch string) error
 		return fmt.Errorf("%sTarget %s not found in manifest", errPrefix, arch)
 	}
 
-	templateData, stErr := setupTemplateData(errPrefix,
-		repo, pkg, arch, targetSpec)
+	templateData, stErr := setupTemplateData(repo, pkg, arch, targetSpec, errPrefix)
 	if stErr != nil {
 		return stErr
 	}

--- a/lemurbldr/impl/paths.go
+++ b/lemurbldr/impl/paths.go
@@ -68,6 +68,6 @@ func getAllRpmsDestDir() string {
 	return filepath.Join(viper.GetString("DestDir"), "RPMS")
 }
 
-func getPkgRpmsDestDir(pkg string) string {
-	return filepath.Join(getAllRpmsDestDir(), pkg)
+func getPkgRpmsDestDir(pkg string, arch string) string {
+	return filepath.Join(getAllRpmsDestDir(), arch, pkg)
 }

--- a/lemurbldr/util/download.go
+++ b/lemurbldr/util/download.go
@@ -40,12 +40,12 @@ func Download(srcURL string, targetDir string, srcDir string) (string, error) {
 		if uri.Scheme != "http" && uri.Scheme != "https" {
 			return "", fmt.Errorf("util.download: Unsupported URL scheme. (Supported: file, http, https")
 		}
-		dstPath := filepath.Join(targetDir, filename)
+		destPath := filepath.Join(targetDir, filename)
 
 		var file *os.File
-		file, createErr := os.Create(dstPath)
+		file, createErr := os.Create(destPath)
 		if createErr != nil {
-			return "", fmt.Errorf("util.download: Error creating %s", dstPath)
+			return "", fmt.Errorf("util.download: Error creating %s", destPath)
 		}
 		defer file.Close()
 

--- a/lemurbldr/util/util.go
+++ b/lemurbldr/util/util.go
@@ -87,7 +87,8 @@ func GetMatchingFilenamesFromDir(
 }
 
 // CopyFilesToDir copies files in filelist from srcDir to destDir
-// It expects destDir to be already present.
+// It expects srcDir to be already present, destDir can be created with
+// prefixes on demand.
 func CopyFilesToDir(fileList []string, srcDir string, destDir string,
 	retainInSrc bool,
 	errPrefix ErrPrefix) error {
@@ -96,9 +97,13 @@ func CopyFilesToDir(fileList []string, srcDir string, destDir string,
 			errPrefix, srcDir, err)
 	}
 
-	if err := CheckPath(destDir, true, true); err != nil {
-		return fmt.Errorf("%s: Expected directory %s to be present and writable. (%s)",
-			errPrefix, destDir, err)
+	if len(fileList) == 0 {
+		return nil
+	}
+
+	if err := RunSystemCmd("mkdir", "-p", destDir); err != nil {
+		return fmt.Errorf("%sError '%s' trying to create directory %s with prefixes",
+			errPrefix, err, destDir)
 	}
 
 	cmd := "cp"


### PR DESCRIPTION
    Directory structure is now <DestDir>/RPMS/<rpmArch>/<package>/foo.<rpmArch>.rpm
    This is what Abuild expects. This makes sure that any noarch rpms aren't
    duplicated when two arch builds are run one after the other. So we can publish
    i686 and x86_64 build results under one yum repo.

    Fix tests to make sure they test files are indeed created in <DestDir>.
   
    * Also cleanup code to be more uniform