### PR TITLE
Refactor mock and createSrpm

### DIFF
--- a/lemurbldr/impl/common.go
+++ b/lemurbldr/impl/common.go
@@ -8,7 +8,33 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/viper"
+
+	"lemurbldr/util"
 )
+
+// copyFromRepoSrcDir is a helper that copies file named srcFile
+// from the repo directory to the directory path destDir
+func copyFromRepoSrcDir(repo string, srcFile string,
+	destDir string,
+	errPrefix util.ErrPrefix) error {
+	repoSrcDir := getRepoSrcDir(repo)
+	srcFilePath := filepath.Join(repoSrcDir, srcFile)
+
+	if util.CheckPath(srcFilePath, false, false) != nil {
+		return fmt.Errorf("%sCannot find source file %s in repo %s to copy to %s",
+			errPrefix, srcFilePath, repo, destDir)
+	}
+
+	if util.CheckPath(destDir, true, true) != nil {
+		return fmt.Errorf("%sdestDir %s should be present and writable",
+			errPrefix, destDir)
+	}
+
+	if err := util.CopyFile(srcFilePath, destDir, errPrefix); err != nil {
+		return err
+	}
+	return nil
+}
 
 func getRepoSrcDir(repo string) string {
 	srcDir := viper.GetString("SrcDir")

--- a/lemurbldr/impl/common.go
+++ b/lemurbldr/impl/common.go
@@ -36,6 +36,28 @@ func copyFromRepoSrcDir(repo string, srcFile string,
 	return nil
 }
 
+// filterAndCopy copies files from srcDirPath to a specified
+// destDirPath depending on filename.
+// movePathMap is a map from destDirPath to regex.
+// We walk through all files in srcDirPath and see if any regex in the map matches.
+// If it matches, files are moved to the destDirPath corresponding to the regex.
+// destDirPath is created if it doesn't exist.
+func filterAndCopy(movePathMap map[string]string, srcDirPath string,
+	errPrefix util.ErrPrefix) error {
+	for destDirPath, regexStr := range movePathMap {
+		filenames, gmfdErr := util.GetMatchingFilenamesFromDir(srcDirPath, regexStr, errPrefix)
+		if gmfdErr != nil {
+			return gmfdErr
+		}
+		if err := util.CopyFilesToDir(filenames, srcDirPath, destDirPath, true, errPrefix); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Path getters
+
 func getRepoSrcDir(repo string) string {
 	srcDir := viper.GetString("SrcDir")
 	return filepath.Join(srcDir, repo)

--- a/lemurbldr/impl/mock.go
+++ b/lemurbldr/impl/mock.go
@@ -5,7 +5,6 @@ package impl
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -13,125 +12,156 @@ import (
 	"lemurbldr/util"
 )
 
-func fedoraMock(pkg string, arch string, srpmPath string) error {
-	errPrefix := util.ErrPrefix(fmt.Sprintf("fedoraMock(%s-%s): ", pkg, arch))
-
-	var mockArgs []string
-
-	mockResultsDir := getMockResultsDir(pkg, arch)
-	targetArg := "--target=" + arch
-	cfgArg := "--root=" + getMockCfgPath(pkg, arch)
-	mockArgs = append(mockArgs, fmt.Sprintf("--resultdir=%s", mockResultsDir), targetArg, cfgArg, srpmPath)
-	if util.GlobalVar.Quiet {
-		mockArgs = append(mockArgs, "--quiet")
-	}
-
-	mockErr := util.RunSystemCmd("mock", mockArgs...)
-	if mockErr != nil {
-		return fmt.Errorf("%smock %s on arch %s errored out with %s",
-			errPrefix, pkg, arch, mockErr)
-	}
-
-	return nil
+type mockBuilder struct {
+	pkg        string
+	repo       string
+	targetSpec *manifest.Target
+	errPrefix  util.ErrPrefix
+	srpmPath   string
 }
 
-// filterAndCopy copies files from srcDirPath to a specified
-// destDirPath depending on filename.
-// movePathMap is a map from destDirPath to regex.
-// We walk through all files in srcDirPath and see if any regex in the map matches.
-// If it matches, files are moved to the destDirPath corresponding to the regex.
-// destDirPath is created if it doesn't exist.
-func filterAndCopy(movePathMap map[string]string, srcDirPath string,
-	errPrefix util.ErrPrefix) error {
-	for destDirPath, regexStr := range movePathMap {
-		filenames, gmfdErr := util.GetMatchingFilenamesFromDir(srcDirPath, regexStr, errPrefix)
-		if gmfdErr != nil {
-			return gmfdErr
-		}
-		if err := util.CopyFilesToDir(filenames, srcDirPath, destDirPath, true, errPrefix); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Build one SRPM
-func mock(repo string, pkgSpec manifest.Package, arch string) error {
-	pkg := pkgSpec.Name
-
-	errPrefix := util.ErrPrefix(fmt.Sprintf("impl.mock(%s-%s): ", pkg, arch))
-
-	pkgSrpmsDir := getPkgSrpmsDestDir(pkg)
+func (bldr *mockBuilder) fetchSrpm() error {
+	pkgSrpmsDir := getPkgSrpmsDestDir(bldr.pkg)
 	if err := util.CheckPath(pkgSrpmsDir, true, false); err != nil {
 		return fmt.Errorf("%sDirectory %s not found, input .src.rpm is expected here",
-			errPrefix, pkgSrpmsDir)
+			bldr.errPrefix, pkgSrpmsDir)
 	}
 
-	srpmNames, gmfdErr := util.GetMatchingFilenamesFromDir(pkgSrpmsDir, "", errPrefix)
+	srpmNames, gmfdErr := util.GetMatchingFilenamesFromDir(pkgSrpmsDir, "", bldr.errPrefix)
 	if gmfdErr != nil {
 		return gmfdErr
 	}
 	if numMatched := len(srpmNames); numMatched != 1 {
 		return fmt.Errorf("%sFound %d files in %s, expected (only) one .src.rpm file",
-			errPrefix, numMatched, pkgSrpmsDir)
+			bldr.errPrefix, numMatched, pkgSrpmsDir)
 	}
+
 	srpmName := srpmNames[0]
 	srpmPath := filepath.Join(pkgSrpmsDir, srpmName)
 	if !strings.HasSuffix(srpmName, ".src.rpm") {
-		return fmt.Errorf("%sFile %s found, but expected a .src.rpm file here", errPrefix, srpmPath)
+		return fmt.Errorf("%sFile %s found, but expected a .src.rpm file here", bldr.errPrefix, srpmPath)
+	}
+	bldr.srpmPath = srpmPath
+	return nil
+}
+
+func (bldr *mockBuilder) rpmArchs() []string {
+	return []string{"noarch", bldr.targetSpec.Name}
+}
+
+func (bldr *mockBuilder) clean() error {
+	var dirs []string
+	for _, rpmArch := range bldr.rpmArchs() {
+		dirs = append(dirs, getPkgRpmsDestDir(bldr.pkg, rpmArch))
 	}
 
-	// These should be created but not cleaned up
-	dirsToSetup := []string{getPkgWorkingDir(pkg)}
-	if err := util.CreateDirs(dirsToSetup, false, errPrefix); err != nil {
+	arch := bldr.targetSpec.Name
+	dirs = append(dirs, getMockBaseDir(bldr.pkg, arch))
+	if err := util.RemoveDirs(dirs, bldr.errPrefix); err != nil {
 		return err
 	}
+	return nil
+}
 
-	// These should be cleaned up and re-created
-	mockBaseDir := getMockBaseDir(pkg, arch)
-	mockResultsDir := getMockResultsDir(pkg, arch)
-	mockCfgDir := getMockCfgDir(pkg, arch)
-	dirsToWipeAndRecreate := []string{mockBaseDir, mockResultsDir, mockCfgDir}
-	if err := util.CreateDirs(dirsToWipeAndRecreate, true, errPrefix); err != nil {
+func (bldr *mockBuilder) createCfg() error {
+	cfgBldr := mockCfgBuilder{
+		bldr.pkg,
+		bldr.repo,
+		bldr.targetSpec,
+		util.ErrPrefix(fmt.Sprintf("mockCfgBuilder(%s-%s", bldr.pkg, bldr.targetSpec.Name)),
+		nil,
+	}
+
+	if err := cfgBldr.populateTemplateData(); err != nil {
 		return err
 	}
+	if err := cfgBldr.prep(); err != nil {
+		return err
+	}
+	if err := cfgBldr.createMockCfgFile(); err != nil {
+		return err
+	}
+	return nil
+}
 
-	// Wipe a few more dirs that could be stale
-	// They are created later on after fedoraMock
-	rpmArchs := []string{arch, "noarch"}
-	for _, rpmArch := range rpmArchs {
-		dirToCleanup := getPkgRpmsDestDir(pkg, rpmArch)
-		if err := os.RemoveAll(dirToCleanup); err != nil {
-			return fmt.Errorf("%sError '%s' trying to delete %s",
-				errPrefix, err, dirToCleanup)
-		}
+func (bldr *mockBuilder) runFedoraMock() error {
+	arch := bldr.targetSpec.Name
+
+	var mockArgs []string
+
+	mockResultsDir := getMockResultsDir(bldr.pkg, arch)
+	targetArg := "--target=" + arch
+	cfgArg := "--root=" + getMockCfgPath(bldr.pkg, arch)
+	mockArgs = append(mockArgs,
+		fmt.Sprintf("--resultdir=%s", mockResultsDir),
+		targetArg,
+		cfgArg,
+		bldr.srpmPath)
+
+	if util.GlobalVar.Quiet {
+		mockArgs = append(mockArgs, "--quiet")
 	}
 
-	if mcgErr := createMockCfgFile(repo, pkgSpec, arch); mcgErr != nil {
-		return mcgErr
+	mockErr := util.RunSystemCmd("mock", mockArgs...)
+
+	if mockErr != nil {
+		return fmt.Errorf("%sfedora mock %s on arch %s errored out with %s",
+			bldr.errPrefix, bldr.pkg, arch, mockErr)
 	}
 
-	if fmErr := fedoraMock(pkgSpec.Name, arch, srpmPath); fmErr != nil {
-		return fmErr
-	}
+	return nil
+}
 
-	// Copy built RPMs out to DestDir/RPMS/<rpmArch>/<pkg>/foo.<rpmArch>.rpm
+// Copy built RPMs out to DestDir/RPMS/<rpmArch>/<pkg>/foo.<rpmArch>.rpm
+func (bldr *mockBuilder) copyResultsToDestDir() error {
+	arch := bldr.targetSpec.Name
+
+	mockResultsDir := getMockResultsDir(bldr.pkg, arch)
 	copyPathMap := make(map[string]string)
-	for _, rpmArch := range rpmArchs {
-		pkgRpmsDestDirForArch := getPkgRpmsDestDir(pkg, rpmArch)
+	for _, rpmArch := range bldr.rpmArchs() {
+		pkgRpmsDestDirForArch := getPkgRpmsDestDir(bldr.pkg, rpmArch)
 		rpmArchFilenameRegex := ".+\\.%s\\.rpm$"
 		copyPathMap[pkgRpmsDestDirForArch] = fmt.Sprintf(rpmArchFilenameRegex, rpmArch)
 	}
-	copyErr := filterAndCopy(copyPathMap, mockResultsDir, errPrefix)
+	copyErr := filterAndCopy(copyPathMap, mockResultsDir, bldr.errPrefix)
 	if copyErr != nil {
 		return copyErr
+	}
+	return nil
+}
+
+// This is the entry point to mockBuilder
+// It runs the stages to build the RPMS from a modified SRPM built previously.
+// It expects the SRPM to be already present in <DestDir>/SRPMS/<package>/
+// Stages: Fetch SRPM, Clean, Create Mock Configuration, Run Fedora Mock,
+// CopyResultsToDestDir
+func (bldr *mockBuilder) runStages() error {
+	if err := bldr.fetchSrpm(); err != nil {
+		return err
+	}
+
+	if err := bldr.clean(); err != nil {
+		return err
+	}
+
+	if err := bldr.createCfg(); err != nil {
+		return err
+	}
+
+	if err := bldr.runFedoraMock(); err != nil {
+		return err
+	}
+
+	if err := bldr.copyResultsToDestDir(); err != nil {
+		return err
 	}
 
 	return nil
 }
 
 // Mock calls fedora mock to build the RPMS for the specified target
-// from the already built SRPMs and places the results in {WorkingDir}/<pkg>/RPMS
+// from the already built SRPMs and places the results in
+// <DestDir>/RPMS/<rpmArch>/<package>/
 func Mock(repo string, pkg string, arch string) error {
 	if err := CheckEnv(); err != nil {
 		return err
@@ -155,7 +185,32 @@ func Mock(repo string, pkg string, arch string) error {
 			continue
 		}
 		found = true
-		if err := mock(repo, pkgSpec, arch); err != nil {
+
+		errPrefix := util.ErrPrefix(fmt.Sprintf(
+			"mockBuilder(%s-%s): ",
+			thisPkgName, arch))
+
+		targetValid := false
+		var targetSpec manifest.Target
+		for _, targetSpec = range pkgSpec.Target {
+			if targetSpec.Name == arch {
+				targetValid = true
+				break
+			}
+		}
+
+		if !targetValid {
+			return fmt.Errorf("%sTarget %s not found in manifest", errPrefix, arch)
+		}
+
+		bldr := &mockBuilder{
+			thisPkgName,
+			repo,
+			&targetSpec,
+			errPrefix,
+			"",
+		}
+		if err := bldr.runStages(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Make mock and createSrpm to be more linear.
Have it cleanup and prep dirs in common places.
Use receivers instead of passing data to functions.

These changes will help in adding new features:
1. BuildRequires coming from configuration instead of manifest.
2. Mock variants for noclean/init etc.