### PR TITLE
lemurbldr: Don't specify target in manifest

### DIFF
--- a/lemurbldr/cmd/testData/mrtparse-1/lemurbldr.yaml
+++ b/lemurbldr/cmd/testData/mrtparse-1/lemurbldr.yaml
@@ -6,12 +6,11 @@ package:
     upstream:
       - file:///mrtparse-2.0.1.tar.gz
     type: tarball
-    target:
-      - name: x86_64
-        include:
-          - a.tpl
-        repo:
-          - name: BaseOS
-            version: "artifactory/alma-linux/9.1"
-          - name: AppStream
-            version: "artifactory/alma-linux/9.1"
+    build:
+      include:
+        - a.tpl
+      repo:
+        - name: BaseOS
+          version: "artifactory/alma-linux/9.1"
+        - name: AppStream
+          version: "artifactory/alma-linux/9.1"

--- a/lemurbldr/cmd/testData/mrtparse-2/lemurbldr.yaml
+++ b/lemurbldr/cmd/testData/mrtparse-2/lemurbldr.yaml
@@ -6,12 +6,11 @@ package:
     upstream:
       - file:///mrtparse-2.0.1.tar.gz
     type: tarball
-    target:
-      - name: x86_64
-        include:
-          - a.tpl
-        repo:
-          - name: BaseOS
-            version: "artifactory/alma-linux/9.1"
-          - name: AppStream
-            version: "artifactory/alma-linux/9.1"
+    build:
+      include:
+        - a.tpl
+      repo:
+        - name: BaseOS
+          version: "artifactory/alma-linux/9.1"
+        - name: AppStream
+          version: "artifactory/alma-linux/9.1"

--- a/lemurbldr/manifest/manifest.go
+++ b/lemurbldr/manifest/manifest.go
@@ -20,10 +20,9 @@ type Repo struct {
 	Version string `yaml:"version"`
 }
 
-// Target spec
+// Build spec
 // mock cfg is generated for each target depending on this
-type Target struct {
-	Name    string   `yaml:"name"`
+type Build struct {
 	Include []string `yaml:"include"`
 	Repo    []Repo   `yaml:"repo"`
 }
@@ -38,7 +37,7 @@ type Package struct {
 	RpmReleaseMacro string   `yaml:"release"`
 	UpstreamSrc     []string `yaml:"upstream"`
 	Type            string   `yaml:"type"`
-	Target          []Target `yaml:"target"`
+	Build           Build    `yaml:"build"`
 }
 
 // Manifest spec

--- a/lemurbldr/manifest/testData/sampleManifest1.yaml
+++ b/lemurbldr/manifest/testData/sampleManifest1.yaml
@@ -5,21 +5,15 @@ package:
     upstream:
       - http://foo/libpcap.src.rpm
     type: srpm
-    target:
-      - name: i686
-        include:
-          - a.tpl
-        repo:
-          - name: BaseOS
-            version: foo/bar
+    build:
+      repo:
+        - name: BaseOS
+          version: foo/bar
   - name: tcpdump
     upstream:
       - http://foo/tcpdump.src.rpm
     type: srpm
-    target:
-      - name: i686
-        include:
-          - a.tpl
-        repo:
-          - name: AppStream
-            version: foo
+    build:
+      repo:
+        - name: BaseOS
+          version: foo/bar


### PR DESCRIPTION
Target need to be in manifest. Also repos's need be repeated per target, since the arch is a parameter in baseURLFormat.
Rename TargetSpec as BuildSpec, just specify the repos for now in it, and let it be a singleton instead of a list.