### PR TITLE
barney: Pull docker base image from quay.io

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -7,7 +7,7 @@ images:
 
   internal/alma-9.1-bootstrap:
     units:
-      - image: barney.ci/docker%image/docker.corp.arista.io/almalinuxorg/9-minimal//9.1-20230222
+      - image: barney.ci/docker%image/quay.io/almalinuxorg/9-minimal//9.1-20230222
       - sources: []
         build: |
           mkdir -p /dest/etc


### PR DESCRIPTION
Pull official quay.io docker image instead of the mirror in docker.corp.arista.io. This is to ensure that same image name and tag can be used for pulling both x86 and arm images.