### PR TITLE
eext: Make sure archives are deterministic

### DIFF
--- a/configfiles/mock.cfg.template
+++ b/configfiles/mock.cfg.template
@@ -2,6 +2,7 @@ config_opts['chroot_setup_cmd'] = "install bash bzip2 coreutils cpio diffutils r
 config_opts['package_manager'] = "dnf"
 config_opts['releasever'] = "9"
 config_opts['cleanup_on_failure'] = False
+config_opts['cleanup_on_success'] = False
 {{range $key,$val := .DefaultCommonCfg}}
 config_opts['{{$key}}'] = "{{$val}}"
 {{end}}

--- a/impl/mock.go
+++ b/impl/mock.go
@@ -140,6 +140,8 @@ func (bldr *mockBuilder) mockArgs(extraArgs []string) []string {
 
 	macros := map[string]string{
 		"release": bldr.rpmReleaseMacro,
+		// this macro ensures that static libraries are determinstic
+		"__brp_strip_static_archive": "/usr/lib/rpm/brp-strip-static-archive \"%{__strip} -D\"",
 	}
 
 	var defineArgs []string
@@ -167,11 +169,13 @@ func (bldr *mockBuilder) mockArgs(extraArgs []string) []string {
 
 func (bldr *mockBuilder) runMockCmd(extraArgs []string) error {
 	mockArgs := bldr.mockArgs(extraArgs)
+	bldr.log("Running mock %s", strings.Join(mockArgs, " "))
 	mockErr := util.RunSystemCmd("mock", mockArgs...)
 	if mockErr != nil {
 		return fmt.Errorf("%smock %s errored out with %s",
 			bldr.errPrefix, strings.Join(mockArgs, " "), mockErr)
 	}
+	bldr.log("mock successful")
 	return nil
 }
 


### PR DESCRIPTION
binutils on el9 is built with `enable_deterministic_archives 0` This means that ar and strip add timestamps to static archives by default. We need to pass -D explicitly to both to make them deterministic.

el9 defines these in /usr/lib/rpm/redhat/macros
```
%__strip            /usr/bin/strip
%__brp_strip_static_archive /usr/lib/rpm/brp-strip-static-archive %{__strip}
```

Also `%__os_install_post` calls `%__brp_strip_static_archive` at the end of user-specified `%install`. This goes ahead and strips every static library in $RPM_BUILD_ROOT.

We're overriding %__brp_strip_static_archive to say `/usr/lib/rpm/brp-strip-static-archive "%{__strip} -d"`, With this we'll get determinstic archives with rpmbuild.

And this is important for buildcache stability in Abuild.