### PR TITLE
changes for building i686 rpms with alma vault mirrors

### DIFF
--- a/cmd/testData/mrtparse-1/eext.yaml
+++ b/cmd/testData/mrtparse-1/eext.yaml
@@ -14,6 +14,6 @@ package:
         - a.tpl
       repo:
         - name: BaseOS
-          version: "artifactory/alma-linux/9.1"
+          version: 9.1
         - name: AppStream
-          version: "artifactory/alma-linux/9.1"
+          version: default

--- a/cmd/testData/mrtparse-2/eext.yaml
+++ b/cmd/testData/mrtparse-2/eext.yaml
@@ -13,6 +13,6 @@ package:
         - a.tpl
       repo:
         - name: BaseOS
-          version: "artifactory/alma-linux/9.1"
+          version: 9.1
         - name: AppStream
-          version: "artifactory/alma-linux/9.1"
+          version: default

--- a/configfiles/dnfrepoconfig.yaml
+++ b/configfiles/dnfrepoconfig.yaml
@@ -1,4 +1,5 @@
 ---
+# yamllint disable rule:line-length
 repo:
   AppStream:
     baseurl: "{{.Host}}/artifactory/alma-vault/{{.Version}}/AppStream/{{.Arch}}/os"
@@ -14,4 +15,5 @@ repo:
 
 version-labels:
   default: 9.1
-  latest: 9.2 # Don't use this if you want reproducible builds, this is just for experiments
+  # Don't use latest if you want reproducible builds, this is just for experiments
+  latest: 9.2

--- a/configfiles/dnfrepoconfig.yaml
+++ b/configfiles/dnfrepoconfig.yaml
@@ -1,10 +1,17 @@
 ---
 repo:
   AppStream:
-    baseurl: "{{.Host}}/{{.Version}}/AppStream/{{.Arch}}/os/"
+    baseurl: "{{.Host}}/artifactory/alma-vault/{{.Version}}/AppStream/{{.Arch}}/os"
+
   BaseOS:
-    baseurl: "{{.Host}}/{{.Version}}/BaseOS/{{.Arch}}/os/"
+    baseurl: "{{.Host}}/artifactory/alma-vault/{{.Version}}/BaseOS/{{.Arch}}/os"
+
   CRB:
-    baseurl: "{{.Host}}/{{.Version}}/CRB/{{.Arch}}/os/"
+    baseurl: "{{.Host}}/artifactory/alma-vault/{{.Version}}/CRB/{{.Arch}}/os"
+
   epel:
     baseurl: "{{.Host}}/{{.Version}}/{{.Arch}}/"
+
+version-labels:
+  default: 9.1
+  latest: 9.2 # Don't use this if you want reproducible builds, this is just for experiments

--- a/impl/mock_cfg.go
+++ b/impl/mock_cfg.go
@@ -55,6 +55,7 @@ func (cfgBldr *mockCfgBuilder) populateTemplateData() error {
 			repoSpecifiedInManifest.Name,
 			arch,
 			repoSpecifiedInManifest.Version,
+			repoSpecifiedInManifest.UseBaseArch,
 			cfgBldr.errPrefix)
 
 		if err != nil {

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -16,8 +16,9 @@ import (
 // Repo spec
 // mock cfg dnf.conf is generated from this
 type Repo struct {
-	Name    string `yaml:"name"`
-	Version string `yaml:"version"`
+	Name        string `yaml:"name"`
+	Version     string `yaml:"version"`
+	UseBaseArch bool   `yaml:"use-base-arch"`
 }
 
 // Build spec

--- a/repoconfig/testData/sample-dnfrepoconfig.yaml
+++ b/repoconfig/testData/sample-dnfrepoconfig.yaml
@@ -2,3 +2,5 @@
 repo:
   repo1:
     baseurl: "{{.Host}}/bar-{{.Version}}/{{.Arch}}/"
+version-labels:
+  latest: 999


### PR DESCRIPTION
The original design was to build i686 RPMs with x86_64 repos itself using multilib, but dnf and mock have been hard to tame to make them do this. So we're planning to build with native alma i686 mirrors available in vault. To make this happen, baseURL derivation has to insert `i686` in repo URL. It's been changed to do this by default unless explicitly asked to add the baseArch of `x86_64` using use-base-arch in the repo configuration in eext.yaml.

I've modified the default dnfrepoconfig.yaml to use alma vault mirrors in the base URL template. The version can be specified specifically like `9.1` or as say `default` or `latest` in case we want to build with new BuildRequires repo when new version comes out and we change `default` in dnfrepoconfig.yaml to point to a new version without any changes to eext.yaml.