### PR TITLE
Don't run installdeps as a separate stage for target i686

### DIFF
--- a/impl/mock.go
+++ b/impl/mock.go
@@ -191,12 +191,16 @@ func (bldr *mockBuilder) runFedoraMockStages() error {
 	}
 	bldr.log("succesful")
 
-	bldr.setupStageErrPrefix("installdeps")
-	bldr.log("starting")
-	if err := bldr.runMockCmd([]string{"--installdeps"}); err != nil {
-		return err
+	// installdeps seems to be broken when run for target i686
+	// Skip separate installdeps stage and run it as part of mock for i686
+	if bldr.arch != "i686" {
+		bldr.setupStageErrPrefix("installdeps")
+		bldr.log("starting")
+		if err := bldr.runMockCmd([]string{"--installdeps"}); err != nil {
+			return err
+		}
+		bldr.log("succesful")
 	}
-	bldr.log("succesful")
 
 	bldr.setupStageErrPrefix("build")
 	buildArgs := []string{"--no-clean", "--rebuild"}


### PR DESCRIPTION
We run installdeps as a separate stage from build to make debugging easier. However, I see that installdeps doesn't handle %ifarch conditionals for BuildRequires and Requires correctly.
I see that `%ifarch x86_64` evaluates to true when run with --target i686, pulling in the wrong dependencies. So don't run it as a separate stage when target is i686.