### PR TITLE
Add support for tagging eext release to unmodified srpms

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -125,8 +125,12 @@ images:
     units:
       - floor: .%eext-testfloor
         build: |
-          go test code.arista.io/eos/tools/eext/...
-          go test code.arista.io/eos/tools/eext/... -tags privileged
+          go test code.arista.io/eos/tools/eext/dnfconfig
+          go test code.arista.io/eos/tools/eext/srcconfig
+          go test code.arista.io/eos/tools/eext/manifest
+          go test code.arista.io/eos/tools/eext/impl
+          go test code.arista.io/eos/tools/eext/cmd
+          go test code.arista.io/eos/tools/eext/cmd -tags privileged
           go vet code.arista.io/eos/tools/eext/...
           test -z "$(gofmt -l .)"
 

--- a/cmd/create_srpm_test.go
+++ b/cmd/create_srpm_test.go
@@ -84,7 +84,7 @@ func TestCreateSrpmFromTarball(t *testing.T) {
 		sources)
 }
 
-func TestCreateSrpmUnmodified(t *testing.T) {
+func TestCreateSrpmFromUnmodifiedSrpm(t *testing.T) {
 	t.Log("Test createSrpm for unmodified")
 	var sources = []string{
 		"code.arista.io/eos/tools/eext#deadbeefdeadbeefdead",
@@ -92,6 +92,6 @@ func TestCreateSrpmUnmodified(t *testing.T) {
 	}
 	testCreateSrpm(t,
 		"debugedit-2", "debugedit", true,
-		[]string{"debugedit-5.0-3.el9.src.rpm"},
+		[]string{"debugedit-5.0-3.el9.deadbee_beefdea.src.rpm"},
 		sources)
 }

--- a/impl/common.go
+++ b/impl/common.go
@@ -196,6 +196,10 @@ func download(srcURL string, targetDir string,
 
 	if uri.Scheme == "file" {
 		pkgDirInRepo := getPkgDirInRepo(repo, pkg, isPkgSubdirInRepo)
+		if uri.Path == "" {
+			return "", fmt.Errorf("%sBad URL %s. Example usage: file:///foo",
+				errPrefix, srcURL)
+		}
 		srcAbsPath := filepath.Join(pkgDirInRepo, uri.Path)
 		if err := util.CheckPath(srcAbsPath, false, false); err != nil {
 			return "", fmt.Errorf("%supstream file %s not found in repo",

--- a/impl/create_srpm_from_unmodified_srpm_test.go
+++ b/impl/create_srpm_from_unmodified_srpm_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package impl
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"code.arista.io/eos/tools/eext/testutil"
+)
+
+func testCreateSrpmFromUnmodifiedSrpm(t *testing.T,
+	upstreamRelease, specFileReleaseLine string) {
+	t.Log("Create temporary working directory")
+	testWorkingDir, mkdirErr := os.MkdirTemp("", "create-srpm-from-unmodified-test")
+	if mkdirErr != nil {
+		t.Fatal(mkdirErr)
+	}
+	defer os.RemoveAll(testWorkingDir)
+
+	srcDir := filepath.Join(testWorkingDir, "src")
+	workDir := filepath.Join(testWorkingDir, "work")
+	destDir := filepath.Join(testWorkingDir, "dest")
+
+	for _, subdir := range []string{srcDir, workDir, destDir} {
+		os.Mkdir(subdir, 0775)
+	}
+
+	t.Log("Copy testData/manifest to src directory")
+	pkg := "unmodified-srpm-pkg"
+	testutil.SetupManifest(t, srcDir, pkg, "unmodified-srpm-pkg/eext.yaml")
+	upstreamVersion := "1.0.0"
+	testutil.SetupUpstreamSrpm(t, srcDir, pkg,
+		upstreamVersion, upstreamRelease, specFileReleaseLine)
+
+	testutil.SetupViperConfig(
+		srcDir,
+		workDir,
+		destDir,
+		"", // depsDir
+		"", // repoHost
+		"", // dnf config file
+		"", // src repo host
+		"", // src config file
+		"", // src repo path prefix
+	)
+	defer viper.Reset()
+	var sources = []string{
+		"code.arista.io/eos/tools/eext#deadbeefdeadbeefdead",
+		"code.arista.io/eos/eext/mrtparse#beefdeadbeefdeadbeef",
+	}
+	testutil.SetupSrcEnv(sources)
+	defer testutil.CleanupSrcEnv(sources)
+
+	createSrpmErr := CreateSrpm(pkg, pkg, CreateSrpmExtraCmdlineArgs{})
+	require.NoError(t, createSrpmErr)
+
+	srpmsResultDir := filepath.Join(destDir, "SRPMS", pkg)
+	require.DirExists(t, srpmsResultDir)
+	expectedEextRelease := "deadbee_beefdea"
+	srpmFile := fmt.Sprintf("%s-%s-%s.%s.src.rpm",
+		pkg, upstreamVersion, upstreamRelease, expectedEextRelease)
+	require.FileExists(t, filepath.Join(srpmsResultDir, srpmFile))
+	t.Log("Results verified to be success")
+}
+
+func TestCreateSrpmFromUnmodifiedSrpm(t *testing.T) {
+	testCreateSrpmFromUnmodifiedSrpm(t, "1.el9", "Release:  1.el9")
+	testCreateSrpmFromUnmodifiedSrpm(t, "1.el9", "Release:  1%{dist}")
+}

--- a/impl/testData/unmodified-srpm-pkg/eext.yaml
+++ b/impl/testData/unmodified-srpm-pkg/eext.yaml
@@ -1,0 +1,12 @@
+---
+# yamllint disable rule:line-length
+package:
+  - name: unmodified-srpm-pkg
+    upstream-sources:
+      - full-url: "file:///unmodified-srpm-pkg-1.0.0-1.el9.src.rpm"
+        signature:
+          skip-check: true
+    type: unmodified-srpm
+    build:
+      repo-bundle:
+        - name: el9


### PR DESCRIPTION
For unmodified srpms, we don't copy the spec file or source files from git repo to the rpmbuild tree.
So they always had the same release as the main spec file.
This means any changes in macros or other build parameters defined in the mock configuration wouldn't affect RPM EVR.
To fix this, make the tool auto patch the upstream spec file in the build tree to include `%{eext-release}` as a suffix after the upstream release.