### PR TITLE
Source bundle for epel packages

### DIFF
--- a/configfiles/srcconfig.yaml
+++ b/configfiles/srcconfig.yaml
@@ -8,3 +8,5 @@ source-bundle:
     default-src-suffix: .tar.gz
     default-sig-suffix: .sig
     has-detached-sig: true
+  epel-srpm:
+    url-format: "{{.Host}}/{{.PathPrefix}}/source-bundles/epel-srpm/{{.PkgName}}/{{.PkgName}}-{{.Version}}.src.rpm"

--- a/srcconfig/testData/sample-srcconfig3.yaml
+++ b/srcconfig/testData/sample-srcconfig3.yaml
@@ -1,0 +1,5 @@
+---
+# yamllint disable rule:line-length
+source-bundle:
+  epel-srpm:
+    url-format: "{{.Host}}/{{.PathPrefix}}/{{.PkgName}}/{{.PkgName}}-{{.Version}}.src.rpm"


### PR DESCRIPTION
Added a source bundle definition for epel-srpm to support epel packages.
All epel srpms can be added to `https://artifactory.infra.corp.arista.io/artifactory/eext-sources/source-bundles/epel-srpm` and eext package can utilize source bundle `epel-srpm` to refer to its srpm.