### PR TITLE
Dependency changes

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,8 +24,8 @@ var buildCmd = &cobra.Command{
 			SkipBuildPrep: commonArgs.skipBuildPrep,
 		}
 		extraMockArgs := impl.MockExtraCmdlineArgs{
-			NoCheck:      commonArgs.noCheck,
-			UseLocalDeps: commonArgs.useLocalDeps}
+			NoCheck: commonArgs.noCheck,
+		}
 
 		if err := impl.Build(repo, pkg, defaultArch(),
 			extraCreateSrpmArgs, extraMockArgs); err != nil {
@@ -40,6 +40,5 @@ func init() {
 	buildCmd.Flags().StringVarP(&pkgName, "package", "p", "", "package name (OPTIONAL)")
 	buildCmd.Flags().BoolVar(&commonArgs.skipBuildPrep, "skip-build-prep", false, "Skips build-prep during createSrpm for cases where build-prep requires dependencies not in container (OPTIONAL)")
 	buildCmd.Flags().BoolVar(&commonArgs.noCheck, "nocheck", false, "Pass --nocheck to rpmbuild (OPTIONAL)")
-	buildCmd.Flags().BoolVar(&commonArgs.useLocalDeps, "use-local-deps", false, "Configure file://RPMS as a high priority local-repo. Used to plumb in other eext packages as dependencies (OPTIONAL)")
 	rootCmd.AddCommand(buildCmd)
 }

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -13,7 +13,6 @@ var commonArgs = struct {
 	skipBuildPrep bool
 	arch          string
 	noCheck       bool
-	useLocalDeps  bool
 }{}
 
 func defaultArch() string {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -36,6 +36,10 @@ func SetViperDefaults() {
 	viper.SetDefault("SrcDir", "")
 	viper.SetDefault("WorkingDir", "/var/eext")
 	viper.SetDefault("DestDir", "/dest")
+
+	// colon separated search paths
+	viper.SetDefault("SrpmsDir", "/dest/SRPMS:/SRPMS")
+
 	viper.SetDefault("DepsDir", "/RPMS")
 
 	viper.SetDefault("MockCfgTemplate", "/usr/share/eext/mock.cfg.template")

--- a/cmd/create_srpm_test.go
+++ b/cmd/create_srpm_test.go
@@ -38,6 +38,7 @@ func testCreateSrpm(t *testing.T,
 		"",                                    // srcDir
 		workingDir,                            // workingDir
 		destDir,                               // destDir
+		"",                                    // srpmsDir
 		"",                                    // depsDir
 		"",                                    // repoHost,
 		"",                                    // dnfConfigFile

--- a/cmd/mock.go
+++ b/cmd/mock.go
@@ -25,7 +25,7 @@ var mockCmd = &cobra.Command{
 		extraArgs := impl.MockExtraCmdlineArgs{
 			NoCheck:       commonArgs.noCheck,
 			OnlyCreateCfg: onlyCreateCfg,
-			UseLocalDeps:  commonArgs.useLocalDeps}
+		}
 		if err := impl.Mock(repo, pkg, commonArgs.arch, extraArgs); err != nil {
 			return err
 		}
@@ -39,6 +39,5 @@ func init() {
 	mockCmd.Flags().StringVarP(&commonArgs.arch, "target", "t", defaultArch(), "target architecture for the rpmbuild (OPTIONAL)")
 	mockCmd.Flags().BoolVar(&onlyCreateCfg, "only-create-cfg", false, "Just create mock configuration, don't run mock (OPTIONAL)")
 	mockCmd.Flags().BoolVar(&commonArgs.noCheck, "nocheck", false, "Pass --nocheck to rpmbuild (OPTIONAL)")
-	mockCmd.Flags().BoolVar(&commonArgs.useLocalDeps, "use-local-deps", false, "Configure file://RPMS as a high priority local-repo. Used to plumb in other eext packages as dependencies (OPTIONAL)")
 	rootCmd.AddCommand(mockCmd)
 }

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -63,9 +63,13 @@ func testMock(t *testing.T, setupSrcEnv bool) {
 
 	repoName := "mrtparse-1"
 	expectedPkgName := "mrtparse"
+
+	// Plumb output of create-srpm to mock
+	srpmsDir := filepath.Join(destDir, "SRPMS")
+
 	testutil.SetupViperConfig(
 		"", // srcDir
-		workingDir, destDir,
+		workingDir, destDir, srpmsDir,
 		"", // depsDir
 		"", // repoHost,
 		"", // dnfConfigFile

--- a/impl/common.go
+++ b/impl/common.go
@@ -252,7 +252,7 @@ func download(srcURL string, targetDir string,
 // filterAndCopy copies files from srcDirPath to a specified
 // destDirPath depending on filename.
 // pathMap is a map from destDirPath to a glob pattern.
-// We walk through all the entries of movePath and then copy files matching
+// We walk through all the entries of pathMap and then copy files matching
 // the glob to the the corresponding destDirPath.
 // Note that we make sure destDirPath is created with parents before copying.
 func filterAndCopy(pathMap map[string]string, errPrefix util.ErrPrefix) error {

--- a/impl/common.go
+++ b/impl/common.go
@@ -96,12 +96,16 @@ func getPkgSrpmsDestDir(pkg string) string {
 	return filepath.Join(getAllSrpmsDestDir(), pkg)
 }
 
-func getAllSrpmsDir() string {
-	return "/SRPMS"
-}
-
-func getPkgSrpmsDir(pkg string) string {
-	return filepath.Join(getAllSrpmsDir(), pkg)
+func getPkgSrpmsDir(errPrefix util.ErrPrefix, pkg string) (string, error) {
+	srpmsDirs := viper.GetString("SrpmsDir")
+	for _, srpmsDir := range strings.Split(srpmsDirs, ":") {
+		thisPath := filepath.Join(srpmsDir, pkg)
+		if util.CheckPath(thisPath, true, false) == nil {
+			return thisPath, nil
+		}
+	}
+	return "", fmt.Errorf("%ssubpath %s not found in any item in SrpmsDir %s",
+		errPrefix, pkg, srpmsDirs)
 }
 
 func getAllRpmsDestDir() string {

--- a/impl/create_srpm_from_unmodified_srpm_test.go
+++ b/impl/create_srpm_from_unmodified_srpm_test.go
@@ -27,6 +27,7 @@ func testCreateSrpmFromUnmodifiedSrpm(t *testing.T,
 	srcDir := filepath.Join(testWorkingDir, "src")
 	workDir := filepath.Join(testWorkingDir, "work")
 	destDir := filepath.Join(testWorkingDir, "dest")
+	srpmsDir := filepath.Join(destDir, "SRPMS")
 
 	for _, subdir := range []string{srcDir, workDir, destDir} {
 		os.Mkdir(subdir, 0775)
@@ -43,6 +44,7 @@ func testCreateSrpmFromUnmodifiedSrpm(t *testing.T,
 		srcDir,
 		workDir,
 		destDir,
+		srpmsDir,
 		"", // depsDir
 		"", // repoHost
 		"", // dnf config file

--- a/impl/create_srpm_from_unmodified_srpm_test.go
+++ b/impl/create_srpm_from_unmodified_srpm_test.go
@@ -36,9 +36,22 @@ func testCreateSrpmFromUnmodifiedSrpm(t *testing.T,
 	t.Log("Copy testData/manifest to src directory")
 	pkg := "unmodified-srpm-pkg"
 	testutil.SetupManifest(t, srcDir, pkg, "unmodified-srpm-pkg/eext.yaml")
+
+	pkgDir := filepath.Join(srcDir, pkg)
+	// SetupManifest should have setup pkgDir
+	_, statErr := os.Stat(pkgDir)
+	if statErr != nil {
+		t.Fatal(pkgDir)
+	}
+
 	upstreamVersion := "1.0.0"
-	testutil.SetupUpstreamSrpm(t, srcDir, pkg,
-		upstreamVersion, upstreamRelease, specFileReleaseLine)
+	testutil.SetupDummyRpm(t,
+		pkgDir, // targetDir
+		pkg, "noarch", upstreamVersion, upstreamRelease, specFileReleaseLine,
+		nil,  // buildRequires
+		nil,  // requires
+		true, // isSource
+	)
 
 	testutil.SetupViperConfig(
 		srcDir,

--- a/impl/mock.go
+++ b/impl/mock.go
@@ -51,31 +51,22 @@ func (bldr *mockBuilder) setupStageErrPrefix(stage string) {
 }
 
 func (bldr *mockBuilder) fetchSrpm() error {
-
-	pkgSrpmsDir := getPkgSrpmsDir(bldr.pkg)
-	pkgSrpmsDestDir := getPkgSrpmsDestDir(bldr.pkg)
-
-	var srpmDir string
-	if util.CheckPath(pkgSrpmsDir, true, false) == nil {
-		srpmDir = pkgSrpmsDir
-	} else if util.CheckPath(pkgSrpmsDestDir, true, false) == nil {
-		srpmDir = pkgSrpmsDestDir
-	} else {
-		return fmt.Errorf("%sExpected one of these directories to be present: %s:%s",
-			bldr.errPrefix, pkgSrpmsDir, pkgSrpmsDestDir)
+	pkgSrpmDir, pkgSrpmDirErr := getPkgSrpmsDir(bldr.errPrefix, bldr.pkg)
+	if pkgSrpmDirErr != nil {
+		return pkgSrpmDirErr
 	}
 
-	filesInPkgSrpmsDir, _ := filepath.Glob(filepath.Join(srpmDir, "*"))
+	filesInPkgSrpmsDir, _ := filepath.Glob(filepath.Join(pkgSrpmDir, "*"))
 	numFilesInPkgSrpmsDir := len(filesInPkgSrpmsDir)
 	var srpmPath string
 	if numFilesInPkgSrpmsDir == 0 {
 		return fmt.Errorf("%sFound no files in  %s, expected to find input .src.rpm file here",
-			bldr.errPrefix, srpmDir)
+			bldr.errPrefix, pkgSrpmDir)
 	}
 	if srpmPath = filesInPkgSrpmsDir[0]; numFilesInPkgSrpmsDir > 1 || !strings.HasSuffix(srpmPath, ".src.rpm") {
 		return fmt.Errorf("%sFound files %s in %s, expected only one .src.rpm file",
 			bldr.errPrefix,
-			strings.Join(filesInPkgSrpmsDir, ","), srpmDir)
+			strings.Join(filesInPkgSrpmsDir, ","), pkgSrpmDir)
 	}
 
 	bldr.srpmPath = srpmPath

--- a/impl/mock_cfg.go
+++ b/impl/mock_cfg.go
@@ -32,7 +32,6 @@ type builderCommon struct {
 	arch              string
 	rpmReleaseMacro   string
 	eextSignature     string
-	useLocalDeps      bool
 	buildSpec         *manifest.Build
 	dnfConfig         *dnfconfig.DnfConfig
 	errPrefix         util.ErrPrefix
@@ -105,7 +104,7 @@ func (cfgBldr *mockCfgBuilder) populateTemplateData() error {
 		}
 	}
 
-	if cfgBldr.useLocalDeps {
+	if cfgBldr.buildSpec.Dependencies != nil {
 		localRepo := &dnfconfig.DnfRepoParams{
 			Name:     "local-deps",
 			BaseURL:  "file://" + getMockDepsDir(cfgBldr.pkg, arch),

--- a/impl/mock_cfg_test.go
+++ b/impl/mock_cfg_test.go
@@ -31,14 +31,20 @@ func testMockConfig(t *testing.T, chained bool) {
 	workDir := filepath.Join(testWorkingDir, "work")
 	destDir := filepath.Join(testWorkingDir, "dest")
 	srpmsDir := filepath.Join(destDir, "SRPMS")
-
 	for _, subdir := range []string{srcDir, workDir, destDir} {
 		os.Mkdir(subdir, 0775)
 	}
 
+	var sampleManifestFile string
+	if chained {
+		sampleManifestFile = "manifest-with-deps.yaml"
+	} else {
+		sampleManifestFile = "manifest.yaml"
+	}
+
 	t.Log("Copy testData/manifest to src directory")
 	pkg := "pkg1"
-	testutil.SetupManifest(t, srcDir, pkg, "manifest.yaml")
+	testutil.SetupManifest(t, srcDir, pkg, sampleManifestFile)
 
 	testutil.SetupViperConfig(
 		srcDir,
@@ -72,7 +78,6 @@ func testMockConfig(t *testing.T, chained bool) {
 			eextSignature:   "my-signature",
 			buildSpec:       &manifestObj.Package[0].Build,
 			dnfConfig:       dnfConfig,
-			useLocalDeps:    chained,
 		},
 	}
 

--- a/impl/mock_cfg_test.go
+++ b/impl/mock_cfg_test.go
@@ -30,6 +30,7 @@ func testMockConfig(t *testing.T, chained bool) {
 	srcDir := filepath.Join(testWorkingDir, "src")
 	workDir := filepath.Join(testWorkingDir, "work")
 	destDir := filepath.Join(testWorkingDir, "dest")
+	srpmsDir := filepath.Join(destDir, "SRPMS")
 
 	for _, subdir := range []string{srcDir, workDir, destDir} {
 		os.Mkdir(subdir, 0775)
@@ -43,6 +44,7 @@ func testMockConfig(t *testing.T, chained bool) {
 		srcDir,
 		workDir,
 		destDir,
+		srpmsDir,
 		"",                        // depsDir
 		"https://foo.org",         // repoHost
 		"testData/dnfconfig.yaml", // dnfConfigFile

--- a/impl/setupDeps_test.go
+++ b/impl/setupDeps_test.go
@@ -46,6 +46,7 @@ func TestSetupDeps(t *testing.T) {
 		srcDir,
 		workDir,
 		destDir,
+		"", // srpms dir
 		depsDir,
 		"", // repoHost
 		"", // dnf config file

--- a/impl/setupDeps_test.go
+++ b/impl/setupDeps_test.go
@@ -4,6 +4,7 @@
 package impl
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,8 +12,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"code.arista.io/eos/tools/eext/manifest"
 	"code.arista.io/eos/tools/eext/testutil"
-	"code.arista.io/eos/tools/eext/util"
 )
 
 func TestSetupDeps(t *testing.T) {
@@ -27,20 +28,14 @@ func TestSetupDeps(t *testing.T) {
 	workDir := filepath.Join(testWorkingDir, "work")
 	destDir := filepath.Join(testWorkingDir, "dest")
 	depsDir := filepath.Join(testWorkingDir, "deps")
-	dummyDep := "dummyDepDir/dummyDep"
-	dummyDepDir := filepath.Join(depsDir, filepath.Dir(dummyDep))
 
-	for _, subdir := range []string{srcDir, workDir, destDir, depsDir, dummyDepDir} {
+	for _, subdir := range []string{srcDir, workDir, destDir, depsDir} {
 		os.Mkdir(subdir, 0775)
-	}
-
-	if err := util.RunSystemCmd("touch", filepath.Join(depsDir, dummyDep)); err != nil {
-		panic("Failed to touch dummyDep")
 	}
 
 	t.Log("Copy testData/manifest to src directory")
 	pkg := "pkg1"
-	testutil.SetupManifest(t, srcDir, pkg, "manifest.yaml")
+	testutil.SetupManifest(t, srcDir, pkg, "manifest-with-deps.yaml")
 
 	testutil.SetupViperConfig(
 		srcDir,
@@ -56,21 +51,41 @@ func TestSetupDeps(t *testing.T) {
 	)
 	defer viper.Reset()
 
+	depPkg := "foo"
+	depPkgArch := "noarch"
+	depVersion := "1.0.0"
+	depRelease := "1"
+	t.Log("Loading manifest")
+
+	manifestObj, manifestErrr := manifest.LoadManifest(pkg)
+	require.NoError(t, manifestErrr)
+	require.NotNil(t, manifestObj)
+	require.Equal(t, pkg, manifestObj.Package[0].Name)
+	require.NotNil(t, manifestObj.Package[0].Build)
+	require.NotNil(t, manifestObj.Package[0].Build.Dependencies)
+	require.Equal(t, depPkg, manifestObj.Package[0].Build.Dependencies[0])
+
+	testutil.SetupDummyDependency(t, depsDir,
+		depPkg, depPkgArch, depVersion, depRelease)
+
 	bldr := mockBuilder{
 		builderCommon: &builderCommon{
-			pkg:  pkg,
-			arch: "x86_64",
+			pkg:       pkg,
+			arch:      "x86_64",
+			buildSpec: &manifestObj.Package[0].Build,
 		},
 	}
 
 	t.Log("Running setupDeps")
-	err = bldr.setupDeps()
-	require.NoError(t, err)
+	setupDepsErr := bldr.setupDeps()
+	require.NoError(t, setupDepsErr)
 	t.Log("Ran setupDeps, verifying results")
 
 	depsWorkDir := filepath.Join(workDir, pkg, "mock-x86_64/mock-deps")
-	require.DirExists(t, depsWorkDir)
-	require.FileExists(t, filepath.Join(depsWorkDir, dummyDep))
+	expectedDummyDepDir := filepath.Join(depsWorkDir, depPkgArch, depPkg)
+	expectedDummyDepFilename := fmt.Sprintf("%s-%s-%s.%s.rpm", depPkg, depVersion, depRelease, depPkgArch)
+	expectedDummyDepFilepath := filepath.Join(expectedDummyDepDir, expectedDummyDepFilename)
+	require.FileExists(t, expectedDummyDepFilepath)
 	require.DirExists(t, filepath.Join(depsWorkDir, "repodata"))
 	t.Log("Results verified")
 }

--- a/impl/testData/manifest-with-deps.yaml
+++ b/impl/testData/manifest-with-deps.yaml
@@ -1,0 +1,21 @@
+---
+package:
+  - name: pkg1
+    upstream-sources:
+      - full-url: http://foo.org/pkg1.src.rpm
+    type: srpm
+    build:
+      repo-bundle:
+        - name: bundle-boo1
+          override:
+            repo-roo11:
+              enabled: true
+              exclude: "roo1-rpm.rpm"
+            repo-roo12:
+              enabled: false
+        - name: bundle-boo2
+          version: v2
+        - name: bundle-boo2
+          version: latest
+      dependencies:
+        - foo

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -45,20 +45,6 @@ type Multilib struct {
 	OtherArchPattern  MultilibRpmFilenamePattern `yaml:"other-arch"`
 }
 
-// Dependency spec
-// Used to specify a dependency to be consumed by the generator
-//
-// Dependency is a tuple of repo and package.
-//
-// Repo can specify some other barney repo like "code.arista.io/eos/eext/<depRepoName>"
-// It can also point to current repo with "."
-//
-// Package can be left empty when the specified repo has only one package.
-type Dependency struct {
-	Repo    string `yaml:"repo"`
-	Package string `yaml:"package"`
-}
-
 // Generator spec
 // Used only by the eextgen barney generator to generate eext commands to build barney images
 //
@@ -68,21 +54,23 @@ type Dependency struct {
 //	Valid options for mock are [ --nocheck ]
 //	Valid options for create-srpm are [ --skip-build-prep ]
 //
-// # Dependencies is a list of other eext package dependencies for this package
-//
 // MultiLib specifies MultiLib spec to generate multilib. It's indexed by native-arch (i686/x86_64).
+//
+// ExternalDependencies is indexed by the dependency name and the value is the barney repo
+// this dependency needs to fetched from
 type Generator struct {
-	CmdOptions   map[string][]string `yaml:"cmd-options"`
-	Multilib     map[string]Multilib `yaml:"multilib"`
-	Dependencies []Dependency        `yaml:"dependencies"`
+	CmdOptions           map[string][]string `yaml:"cmd-options"`
+	Multilib             map[string]Multilib `yaml:"multilib"`
+	ExternalDependencies map[string]string   `yaml:"external-dependencies"`
 }
 
 // Build spec
 // mock cfg is generated for each target depending on this
 type Build struct {
-	Include    []string     `yaml:"include"`
-	RepoBundle []RepoBundle `yaml:"repo-bundle"`
-	Generator  Generator    `yaml:"eextgen"`
+	Include      []string     `yaml:"include"`
+	RepoBundle   []RepoBundle `yaml:"repo-bundle"`
+	Dependencies []string     `yaml:"dependencies"`
+	Generator    Generator    `yaml:"eextgen"`
 }
 
 // DetachedSignature spec

--- a/manifest/testData/sampleManifest1.yaml
+++ b/manifest/testData/sampleManifest1.yaml
@@ -29,16 +29,17 @@ package:
         - name: foo
           version: v1
         - name: bar
+      dependencies:
+        - libpcap
+        - glibc
       eextgen:
         cmd-options:
           mock:
             - "--nocheck"
           create-srpm:
             - "--skip-build-prep"
-        dependencies:
-          - repo: .
-            package: libpcap
-          - repo: code.arista.io/eos/eext/glibc
+        external-dependencies:
+          glibc: code.arista.io/eos/eext/glibc
   - name: binutils
     upstream-sources:
       - source-bundle:

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -197,6 +197,7 @@ func SetupViperConfig(
 	srcDir string,
 	workingDir string,
 	destDir string,
+	srpmsDir string,
 	depsDir string,
 	repoHost string,
 	dnfConfigFile string,
@@ -250,6 +251,7 @@ func SetupViperConfig(
 	// the test works in a barney context
 	viper.Set("SrcEnvPrefix",
 		"XXXSRC_")
+	viper.Set("SrpmsDir", srpmsDir)
 }
 
 // CheckEnv panics if the test hasn't setup the environment correctly


### PR DESCRIPTION
1. Changed manifest format to specify dependencies in package build
   spec.
2. Got rid of --use-local-deps commandline parameter. We set these up
   when manifest has a non-empty `dependencies` config.
3. Modified eextgen spec to only map packages to external dependencies.
4. We map only specified dependencies in the working dir to avoid
   installing unspecified dependencies during mock.
5. Make the path from which eext mock picks up SRPMS configurable