### PR TITLE
Changes to support EPEL rebuild project

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -17,8 +17,8 @@ images:
           export DNF_HOST="https://artifactory.infra.corp.arista.io/artifactory"
           export DNF_ARCH="$(arch)"
           export DNF_DISTRO_REPO="alma-vault/9.1"
-          export DNF_EPEL9_REPO="eext-sources/epel9-frozen-subsets"
-          export DNF_EPEL9_REPO_VERSION="v20230901-1"
+          export DNF_EPEL9_REPO_VERSION="v20240127-1"
+          export DNF_EPEL9_REPO="eext-snapshots-local/epel9/${DNF_EPEL9_REPO_VERSION}/9/Everything"
           echo '#!/bin/sh
           microdnf --assumeyes --installroot=/dest --noplugins --config=/etc/dnf/dnf.conf \
                    --setopt=cachedir=/var/cache/microdnf --setopt=reposdir=/etc/yum.repos.d \
@@ -28,7 +28,7 @@ images:
           rm -rf /etc/yum.repos.d
           mkdir -p /etc/yum.repos.d
           echo "[epel9-subset]
-          baseurl=${DNF_HOST}/${DNF_EPEL9_REPO}/${DNF_EPEL9_REPO_VERSION}/
+          baseurl=${DNF_HOST}/${DNF_EPEL9_REPO}/${DNF_ARCH}/
           enabled=1
           gpgcheck=0
           " > /etc/yum.repos.d/eext-externaldeps.repo
@@ -56,7 +56,7 @@ images:
     units:
       - floor: .%internal/alma-9.1-bootstrap
         sources: []
-        build: install-rpms automake coreutils git rpm rpmdevtools rpm-build make mock python3-devel quilt
+        build: install-rpms autoconf automake coreutils git rpm rpmdevtools rpm-build make mock python3-devel quilt
 
   go-binaries:
     description: |
@@ -106,7 +106,7 @@ images:
       - floor: .%internal/alma-9.1-bootstrap
         sources: []
         build: |
-          install-rpms coreutils rpm rpm-build rpmdevtools automake mock quilt git golang
+          install-rpms autoconf automake coreutils golang git rpm rpmdevtools rpm-build make mock python3-devel quilt
           touch $DESTDIR/etc/resolv.conf
     entry:
       env:

--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -1,10 +1,15 @@
 ---
 # yamllint disable rule:line-length
 repo-bundle:
+# --------------------------------------------------------------------------------------------
+  # The defaults for this bundle points to the second most recent stable dot release 9.x.
+  # Upstream vaults/freezes the previous release repo once a new dot release is stable.
+  # The newest stable dot release keeps on receiving updates, so we use the previous one
+  # to ensure build reproducibility from our end.
   el9:
     gpgcheck: true
     gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
-    baseurl: "{{.Host}}/artifactory/alma-vault/{{.Version}}/{{.RepoName}}/{{.Arch}}/os"
+    baseurl: "{{.Host}}/artifactory/eext-alma-vault/{{.Version}}/{{.RepoName}}/{{.Arch}}/os"
     repo:
       AppStream:
         enabled: true
@@ -18,15 +23,132 @@ repo-bundle:
         enabled: false
     version-labels:
       default: 9.2
-      # Don't use latest if you want reproducible builds, this is just for experiments
-      latest: 9.3
+# --------------------------------------------------------------------------------------------
 
-  epel9-subset:
+# --------------------------------------------------------------------------------------------
+  epel9:
     gpgcheck: true
     gpgkey: file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-9
-    baseurl: "{{.Host}}/artifactory/eext-sources/epel9-frozen-subsets/{{.Version}}/"
+
+    # EPEL doesn't publish i686 RPMs. This ensures that we point to the x86_64 repo
+    # when target is i686. This means we can satisfy EPEL dependencies for i686 targets
+    # provided the dependencies are all noarch.
+    use-base-arch: true
+    baseurl: "{{.Host}}/artifactory/eext-snapshots-local/epel9/{{.Version}}/9/Everything/{{.Arch}}/"
     repo:
       epel9:
         enabled: true
     version-labels:
-      default: v20230901-1
+      # Each version points to a timestamped snapshot of the repo cache of the epel9-unsafe repo.
+      # The eext team is responsible for creating these snapshots.
+      # default points to the latest such snapshot.
+      default: v20240127-1
+# --------------------------------------------------------------------------------------------
+
+# ********************************************************************************************
+# DO NOT use any repo bundles below this unless you know what you're doing.
+# ********************************************************************************************
+
+# --------------------------------------------------------------------------------------------
+  el9-unsafe:
+    # DO NOT use el9-unsafe as a repo-bundle in your eext.yaml unless you know what you're doing.
+    # Use el9 because the defaults there will ensure build reproducibility.
+    # el9-unsafe is used by the eext team for experiments.
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
+
+    # i686 rpms are not offically supported upstream, so it is only available in vault
+    # So point to eext-alma-vault repo for i686 and eext-alma-linux for other archs.
+    baseurl: '{{.Host}}/artifactory/eext-alma-{{if eq .Arch "i686"}}vault{{else}}linux{{end}}/{{.Version}}/{{.RepoName}}/{{.Arch}}/os'
+    repo:
+      AppStream:
+        enabled: true
+      BaseOS:
+        enabled: true
+      CRB:
+        enabled: true
+      devel:
+        enabled: false
+      extras:
+        enabled: false
+    version-labels:
+      # default=9 always points to upstream latest dot release 9.x,
+      # which upstream updates regularly.
+      default: 9
+# --------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------
+  el9-beta-unsafe:
+  # DO NOT use el9-beta-unsafe as a repo-bundle in your eext.yaml
+  # unless you know what you're doing. Use el9 instead because the defaults
+  # there will ensure build reproducibility.
+  # el9-beta-unsafe is used by the eext team for experiments.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
+
+    # upstream always publishes the latest beta to vault.
+    baseurl: '{{.Host}}/artifactory/eext-alma-vault/{{.Version}}/{{.RepoName}}/{{.Arch}}/os'
+    repo:
+      AppStream:
+        enabled: true
+      BaseOS:
+        enabled: true
+      CRB:
+        enabled: true
+      devel:
+        enabled: false
+      extras:
+        enabled: false
+    version-labels:
+      # default always points to upstream latest dot release 9.x's beta version,
+      # which upstream updates regularly.
+      default: 9.3-beta
+# --------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------
+  epel9-unsafe:
+    # DO NOT use epel9-unsafe as a repo-bundle in your eext.yaml
+    # unless you know what you're doing. Use epel9 instead because the defaults
+    # there will ensure build reproducibility.
+    # epel9-unsafe is used by the eext team for creating repo cache snapshots
+    # that are further used to update the epel9 repo-bundle default pointer.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-9
+
+    # EPEL doesn't publish i686 RPMs. This ensures that we point to the x86_64 repo
+    # when target is i686. This means we can satisfy EPEL dependencies for i686 targets
+    # provided the dependencies are all noarch.
+    use-base-arch: true
+    baseurl: "{{.Host}}/artifactory/eext-epel/{{.Version}}/Everything/{{.Arch}}/"
+    repo:
+      epel9:
+        enabled: true
+    version-labels:
+      # default always points to upstream stable repo which receives updates.
+      default: 9
+# --------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------
+  epel9-next-unsafe:
+    # DO NOT use epel9-next-unsafe as a repo-bundle in your eext.yaml
+    # unless you know what you're doing. Use epel9 instead because the defaults
+    # there will ensure build reproducibility.
+    # epel9-beta-unsafe is used by the eext team for experiments.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-9
+
+    # EPEL doesn't publish i686 RPMs. This ensures that we point to the x86_64 repo
+    # when target is i686. This means we can satisfy EPEL dependencies for i686 targets
+    # provided the dependencies are all noarch.
+    use-base-arch: true
+    baseurl: "{{.Host}}/artifactory/eext-epel/next/{{.Version}}/Everything/{{.Arch}}/"
+    repo:
+      epel9:
+        enabled: true
+    version-labels:
+      # default always points to upstream next/beta repo which receives updates.
+      default: 9
+# --------------------------------------------------------------------------------------------

--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2022 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package dnfconfig
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+
+	"code.arista.io/eos/tools/eext/util"
+)
+
+func TestDefaultDnfRepoConfig(t *testing.T) {
+	t.Log("Create temporary working directory")
+
+	repoHost := "https://artifactory.infra.corp.arista.io"
+	viper.Set("DnfRepoHost",
+		"https://artifactory.infra.corp.arista.io")
+	viper.Set("DnfConfigFile", "../configfiles/dnfconfig.yaml")
+	defer viper.Reset()
+
+	t.Log("Testing YAML syntax")
+	dnfConfig, loadErr := LoadDnfConfig()
+	require.NoError(t, loadErr)
+	require.NotNil(t, dnfConfig)
+	t.Log("YAML syntax ok")
+
+	type ExpectedDefaultRepoBundle struct {
+		repoToURLFormatString map[string]string
+		archToArtifactoryRepo map[string]string
+		archToURLFormatArch   map[string]string
+		defaultVersion        string
+	}
+
+	// Format string va_args: repoHost, artifactoryRepo, defaultVersion, urlArch
+	expectedRepoBundles := map[string]ExpectedDefaultRepoBundle{
+		"el9": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"BaseOS": "%s/artifactory/%s/%s/BaseOS/%s/os",
+				"CRB":    "%s/artifactory/%s/%s/CRB/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-alma-vault",
+				"x86_64":  "eext-alma-vault",
+				"aarch64": "eext-alma-vault",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "i686",
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9.2",
+		},
+		"el9-unsafe": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"BaseOS": "%s/artifactory/%s/%s/BaseOS/%s/os",
+				"CRB":    "%s/artifactory/%s/%s/CRB/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-alma-vault",
+				"x86_64":  "eext-alma-linux",
+				"aarch64": "eext-alma-linux",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "i686",
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9",
+		},
+		"el9-beta-unsafe": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"BaseOS": "%s/artifactory/%s/%s/BaseOS/%s/os",
+				"CRB":    "%s/artifactory/%s/%s/CRB/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-alma-vault",
+				"x86_64":  "eext-alma-vault",
+				"aarch64": "eext-alma-vault",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "i686",
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9.3-beta",
+		},
+		"epel9": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"epel9": "%s/artifactory/%s/epel9/%s/9/Everything/%s/",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-snapshots-local",
+				"x86_64":  "eext-snapshots-local",
+				"aarch64": "eext-snapshots-local",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "x86_64", // baseArch
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "v20240127-1",
+		},
+		"epel9-unsafe": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"epel9": "%s/artifactory/%s/%s/Everything/%s/",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-epel",
+				"x86_64":  "eext-epel",
+				"aarch64": "eext-epel",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "x86_64", // baseArch
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9",
+		},
+		"epel9-next-unsafe": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"epel9": "%s/artifactory/%s/next/%s/Everything/%s/",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-epel",
+				"x86_64":  "eext-epel",
+				"aarch64": "eext-epel",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "x86_64", // baseArch
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9",
+		},
+	}
+
+	t.Log("Testing expected defaults")
+	for expectedBundleName, expectedRepoBundle := range expectedRepoBundles {
+		t.Logf("\tTesting repo-bundle %s", expectedBundleName)
+
+		require.Contains(t, dnfConfig.DnfRepoBundleConfig, expectedBundleName)
+		bundleConfig := dnfConfig.DnfRepoBundleConfig[expectedBundleName]
+		require.NotNil(t, bundleConfig)
+
+		for expectedRepo, expectedFormatStr := range expectedRepoBundle.repoToURLFormatString {
+			t.Logf("\t\tTesting repo %s", expectedRepo)
+			for _, arch := range []string{"i686", "x86_64", "aarch64"} {
+				t.Logf("\t\t\tTesting arch %s", arch)
+				repoParams, err := bundleConfig.GetDnfRepoParams(expectedRepo,
+					arch,
+					"",  // versionOverride
+					nil, // repoOverrides
+					util.ErrPrefix("defaultconfig-test"))
+				expectedURL := fmt.Sprintf(expectedFormatStr,
+					repoHost,
+					expectedRepoBundle.archToArtifactoryRepo[arch],
+					expectedRepoBundle.defaultVersion,
+					expectedRepoBundle.archToURLFormatArch[arch])
+				require.NoError(t, err)
+				require.Equal(t, expectedURL, repoParams.BaseURL)
+				t.Logf("\t\t\t arch %s OK", arch)
+			}
+			t.Logf("\t\trepo %s OK", expectedRepo)
+		}
+		t.Logf("\trepo-bundle %s OK", expectedBundleName)
+	}
+
+	t.Log("Testing for unexpected repo-bundles in defaults")
+	require.Equal(t, len(expectedRepoBundles), len(dnfConfig.DnfRepoBundleConfig))
+	t.Log("No unexpected repo-bundles in defaults")
+
+	t.Log("TestDefaultDnfRepoConfig test passed")
+}


### PR DESCRIPTION
commit dfa894086ba7789f388031cda4884ea803228c31 (origin/aajith-new-repo-bundles, aajith-new-repo-bundles)
Author: Arun Ajith S <aajith@arista.com>
Date:   Fri Jan 26 01:55:42 2024 -0800

    Tweaking default dnfconfig.yaml for easier operations

    1. Make the el9 bundle point to vault of Arista local mirror
       (artifactory remote-repo) "eext-alma-vault" which is used only by
       eext instead of the earlier local mirror (artifactory remote-repo)
       "alma-vault" which was used by different applications. The new remote
       repository further point to the same almalinux upstream vault mirror
       that "alma-vault" pointed to.

       Using an exclusive  specific remote repo allows us to manage the remote
       repository cache better.  We can zap it without affecting other users
       and also take snapshots of the cache and have the snapshots better
       represent the eext depset. The cache of the common remote repo will
       of course be larger and lead to more disk usage on artifactory side as
       we might need to retain these snapshots longer.

       Note that we don't use snapshots for the vault in our repo-bundles
       yet. However, we can still take snapshots as part of release process
       and still make eext work or old releases even if upstream mirror that
       the remote repo points to becomes unsupported.

       We keep using the second most recent dot release from vault which
       upstream has frozen to ensure build reproducibility as the main
       repo-bundle el9. This decision has been made for easier operations.
       Otherwise new packages being added to eext might require new
       dependencies not available in the existing snapshot, requiring the
       eext team to keep updating the snapshot when new packages come in.
       Using the second most recent dot release in vault needs no
       intervention from the eext team when a new package comes in as it
       will automatically be pulled in by the remote repo from upsteam, and
       cache is updated as well.

       eext team only needs to update the default pointer of the el9
       repo-bundle when upstream declares a new dot release as stable.
       The eext operations guide (AID12597) specifies details on how the
       default pointer is updated.

       The only drawback is we keep using slightly BuildRequires. This isn't
       much of a drawback as the actual SRPM being built can be from the
       latest dot release (unless ofcourse the BuildRequires needs a newer
       version, which we can deal case-by-case). So as long as the RPM being
       built doesn't statically link to something we pulled in as
       BuildRequires, we're good. This is acceptable.

    2. Add el9-unsafe and el9-beta-unsafe repo-bundles to help the eext team
       run experiments to see if builds are compatible with newer
       Buildrequires. These point to the moving upstream stable repo 9 in
       alma-linux. Strictly speaking, it still points to alma-vault (but to the
       moving target 9) for i686 because i686 is published only to vault as
       it is an officially unsupported release.

    3. Added epel9-unsafe and epel9-next-unsafe repo-bundles which are
       pointing to the Arista local mirror (artifactory-remote-repo)
       eext-epel. This is also exclusive to eext and has the same advantages
       of better manageability. But note that the upstream mirror that the
       remote repo points to is a moving target that gets updates regulary.
       So we cannot use these bundles in eos-trunk or release branches
       because it breaks build reproducibility.

       epel9-next-unsafe can be used for experiments with newer packages.

       The remote repo that epel9-unsafe points to  will be used by the eext
       team to generate a cache which represent eext's depset, and the cache
       will be snapshoted and copied over to a generic repository named with a
       timestamp as a version. Other repo-bundles can point to these
       timestamped(and frozen) snapshots to achieve build reproducibility.

    4. Removed epel9-subset which was a locally managed generic repo which
       was harder to maintain. It has been replaced by the epel9 repository,
       which points to a timestamped snapshot of the remote repsitory caches
       mentioned earlier.
       The eext operations guide (AID12597) specifies steps on how the
       remote repo is used to take a new snapshot and update the default
       pointer of this repo-bundle.

    5. Also added a btest for verifying the sanity of the default dnf
       configuration. Changes to the default config file would now need
       corresponding changes in the test as well. This will allow us to
       catch unintentional/bad changes.

commit 3c25b1e8dd16d30caf9811a9b6b0cda380912e5f
Author: Arun Ajith S <aajith@arista.com>
Date:   Thu Jan 25 23:47:26 2024 -0800

    eext base-image changes

    1. Build eext base image from the new epel snapshot avoid maintenance
       overhead with the epel-frozensubset repo.
       This is the same base snapshot repo used by mock underneath.
    2. Add autoconf to the base-image. A lot of EPEL srpms run autoreconf as
       part of %prep. This helps us avoid needing to do --skip-build-prep.