### PR TITLE
Change dependecy list to arch specific dependecies

### DIFF
--- a/impl/mock_cfg.go
+++ b/impl/mock_cfg.go
@@ -35,6 +35,7 @@ type builderCommon struct {
 	buildSpec         *manifest.Build
 	dnfConfig         *dnfconfig.DnfConfig
 	errPrefix         util.ErrPrefix
+	dependencyList    []string
 }
 
 type mockCfgBuilder struct {
@@ -104,7 +105,7 @@ func (cfgBldr *mockCfgBuilder) populateTemplateData() error {
 		}
 	}
 
-	if cfgBldr.buildSpec.Dependencies != nil {
+	if len(cfgBldr.dependencyList) != 0 {
 		localRepo := &dnfconfig.DnfRepoParams{
 			Name:     "local-deps",
 			BaseURL:  "file://" + getMockDepsDir(cfgBldr.pkg, arch),

--- a/impl/mock_cfg_test.go
+++ b/impl/mock_cfg_test.go
@@ -36,10 +36,13 @@ func testMockConfig(t *testing.T, chained bool) {
 	}
 
 	var sampleManifestFile string
+	var dependencyList []string
 	if chained {
 		sampleManifestFile = "manifest-with-deps.yaml"
+		dependencyList = []string{"foo"}
 	} else {
 		sampleManifestFile = "manifest.yaml"
+		dependencyList = []string{}
 	}
 
 	t.Log("Copy testData/manifest to src directory")
@@ -78,6 +81,7 @@ func testMockConfig(t *testing.T, chained bool) {
 			eextSignature:   "my-signature",
 			buildSpec:       &manifestObj.Package[0].Build,
 			dnfConfig:       dnfConfig,
+			dependencyList:  dependencyList,
 		},
 	}
 

--- a/impl/testData/manifest-with-deps.yaml
+++ b/impl/testData/manifest-with-deps.yaml
@@ -18,4 +18,7 @@ package:
         - name: bundle-boo2
           version: latest
       dependencies:
-        - foo
+        all:
+          - foo
+        i686:
+          - bar

--- a/manifest/testData/sampleManifest1.yaml
+++ b/manifest/testData/sampleManifest1.yaml
@@ -30,8 +30,13 @@ package:
           version: v1
         - name: bar
       dependencies:
-        - libpcap
-        - glibc
+        all:
+          - libpcap
+          - glibc
+        x86_64:
+          - gcc11
+        i686:
+          - iptables
       eextgen:
         cmd-options:
           mock:

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -65,7 +65,7 @@ Name: {{.Name}}
 Version: {{.UpstreamVersion}}
 {{ .SpecFileReleaseLine }}
 BuildArch: {{.Arch}}
-License: foo
+License: {{.Name}}
 
 {{ range .Requires }}
 Requires: {{.}}
@@ -77,7 +77,7 @@ BuildRequires: {{.}}
 
 
 %description
-foo
+{{.Name}}
 
 %prep
 true


### PR DESCRIPTION
Currently we support eext packages to specify a list of dependecies for the package. Some packages reqiure the dependecies only for a specific arch (since dependecies for other archs are available upstream). Hence we support arch specific dependecies for eext packages, allowed archs are 'i686', 'x86_64' and 'all'(both)

Fixes: BUG908812