### PR TITLE
cmd: suppress command usage on execution errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,8 +19,9 @@ var pkgName string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "eext",
-	Short: "Build external packages for EOS",
+	Use:          "eext",
+	SilenceUsage: true,
+	Short:        "Build external packages for EOS",
 	Long: `Modified external packages for EOS Abuild can be specified using a git repository.
 The repository would have a manifest which specifies the upstream SRPM/tarball,
 any Arista specific patches and the modified spec file. The patches and the spec file are also


### PR DESCRIPTION
Cobra, by default, has the odd behaviour of printing out the command usage whenever anything in the command throws an error.

It's really strange to have the mock build fail, for example, and then have the usage for "eext build" displayed.

This change stops printing out usage in all error cases. This includes cases where invalid arguments are provided where, arguably, the usage would be helpful, but in any case, the user can just pass "-h" or "--help" to see the usage instead.