### PR TITLE
Upgrade el9 version to 9.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.3
-FROM quay.io/almalinuxorg/9-minimal:9.3-20231124 AS base
+FROM quay.io/almalinuxorg/9-minimal:9.4-20240506 AS base
 RUN microdnf install -y dnf-4.* && microdnf clean all
 RUN dnf install -y epel-release-9* git-2.* jq-1.* \
     openssl-3.* python3-pip-21.* python3-pyyaml-5.* \

--- a/barney.yaml
+++ b/barney.yaml
@@ -7,7 +7,7 @@ images:
 
   internal/alma-9.1-bootstrap:
     units:
-      - image: barney.ci/docker%image/quay.io/almalinuxorg/9-minimal//9.3-20231124
+      - image: barney.ci/docker%image/quay.io/almalinuxorg/9-minimal//9.4-20240506
       - sources: []
         build: |
           mkdir -p /dest/etc

--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -22,7 +22,7 @@ repo-bundle:
       extras:
         enabled: false
     version-labels:
-      default: 9.2
+      default: 9.3
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -42,7 +42,7 @@ repo-bundle:
       # Each version points to a timestamped snapshot of the repo cache of the epel9-unsafe repo.
       # The eext team is responsible for creating these snapshots.
       # default points to the latest such snapshot.
-      default: v20240127-1
+      default: v20240522-1
 # --------------------------------------------------------------------------------------------
 
 # ********************************************************************************************
@@ -103,7 +103,7 @@ repo-bundle:
     version-labels:
       # default always points to upstream latest dot release 9.x's beta version,
       # which upstream updates regularly.
-      default: 9.3-beta
+      default: 9.4-beta
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------

--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -52,7 +52,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "9.2",
+			defaultVersion: "9.3",
 		},
 		"el9-unsafe": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{
@@ -86,7 +86,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "9.3-beta",
+			defaultVersion: "9.4-beta",
 		},
 		"epel9": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{
@@ -102,7 +102,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "v20240127-1",
+			defaultVersion: "v20240522-1",
 		},
 		"epel9-unsafe": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{


### PR DESCRIPTION
With AlmaLinux 9.4 stable released, 9.3 el9 rpms have been vaulted. Hence we can upgrade the el9 repo version to 9.3.
This upgrade involves:
1. Moving el9 repo version to 9.3
2. Updating epel9 snapshot with latest package deps (v20240522-1)
3. Updating docker image to v9.4-20240506 