### PR TITLE
Add support for el9 snapshot

### DIFF
--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -49,11 +49,34 @@ repo-bundle:
 # DO NOT use any repo bundles below this unless you know what you're doing.
 # ********************************************************************************************
 
+#---------------------------------------------------------------------------------------------
+  el9-snapshot:
+    # DO NOT use el9-snapshot as a repo-bundle in your eext.yaml, unless recommended to you by the eext team.
+    # el9-snapshot is a snapshot of the repo cache of el9-unsafe.
+    # The eext team is responsible for creating these snapshots.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
+    baseurl: '{{.Host}}/artifactory/eext-snapshots-local/el9/{{.Version}}/9/{{.RepoName}}/{{.Arch}}/os'
+    repo:
+      AppStream:
+        enabled: true
+      BaseOS:
+        enabled: true
+      CRB:
+        enabled: true
+      devel:
+        enabled: false
+      extras:
+        enabled: false
+#---------------------------------------------------------------------------------------------
+
 # --------------------------------------------------------------------------------------------
   el9-unsafe:
     # DO NOT use el9-unsafe as a repo-bundle in your eext.yaml unless you know what you're doing.
     # Use el9 because the defaults there will ensure build reproducibility.
     # el9-unsafe is used by the eext team for experiments.
+
     gpgcheck: true
     gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
 

--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -54,6 +54,23 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 			},
 			defaultVersion: "9.3",
 		},
+		"el9-snapshot": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"BaseOS": "%s/artifactory/%s/el9/default/%s/BaseOS/%s/os",
+				"CRB":    "%s/artifactory/%s/el9/default/%s/CRB/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-snapshots-local",
+				"x86_64":  "eext-snapshots-local",
+				"aarch64": "eext-snapshots-local",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "i686",
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "9",
+		},
 		"el9-unsafe": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{
 				"BaseOS": "%s/artifactory/%s/%s/BaseOS/%s/os",


### PR DESCRIPTION
Adding el9-snapshot repo-bundle to help the eext team run experiments to see if builds are compatible with newer Buildrequires. These point to a snapshot captured at the given date of the el9 upstream repo of alma-linux (x86_64 and aarch64 rpms) and alma-vault (i686 rpms).