### PR TITLE
barney: migrate to barney.context

### DIFF
--- a/barney.context
+++ b/barney.context
@@ -1,0 +1,23 @@
+{
+	"version": 1,
+	"repomap": {
+		"barney.ci/alpine": {
+			"commit": "957357dfbb603385c9c0aebee8b1bfcc4244e3d9"
+		},
+		"barney.ci/barneyfile": {
+			"commit": "963a03aa0fc5f96fbe785a7505c7876667015ce0"
+		},
+		"barney.ci/docker": {
+			"commit": "dcf06383f24b7666deaf18869d2bc92455195782"
+		},
+		"barney.ci/golang": {
+			"commit": "dd612eba506a1c084a80920c879586c5ca196f7a"
+		},
+		"barney.ci/model": {
+			"commit": "5e45f4f5d84591798dfe23a44c5e9e7d5735c580"
+		},
+		"github.com/golang/go": {
+			"commit": "8e1fdea8316d840fd07e9d6e026048e53290948b"
+		}
+	}
+}


### PR DESCRIPTION
Use barney.context for the repomap to make it more visibile and make repomap updates more visible.