### PR TITLE
Add fedora repo support for eext

### DIFF
--- a/cmd/testData/mrtparse-2/eext.yaml
+++ b/cmd/testData/mrtparse-2/eext.yaml
@@ -14,3 +14,4 @@ package:
       repo-bundle:
         - name: el9
           version: 9.1
+          priority: 2

--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -74,6 +74,25 @@ repo-bundle:
     priority: 2
 #---------------------------------------------------------------------------------------------
 
+#---------------------------------------------------------------------------------------------
+  fc40-snapshot:
+    # DO NOT use fc40-snapshot as a repo-bundle in your eext.yaml,
+    # unless recommended to you by the eext team.
+    # The eext team is responsible for creating these snapshots.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-40-primary
+
+    # fc40 publishes i686 RPMS in x86_64 repo. This ensures that we point to the x86_64 repo
+    # when target is i686.
+    use-base-arch: true
+    baseurl: "{{.Host}}/artifactory/eext-snapshots-local/fc40/{{.Version}}/{{.RepoName}}/40/Everything/{{.Arch}}/os"
+    repo:
+      releases:
+        enabled: true
+    priority: 3
+#---------------------------------------------------------------------------------------------
+
 # --------------------------------------------------------------------------------------------
   el9-unsafe:
     # DO NOT use el9-unsafe as a repo-bundle in your eext.yaml unless you know what you're doing.
@@ -182,3 +201,25 @@ repo-bundle:
       default: 9
     priority: 2
 # --------------------------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------------------------
+  fc40-unsafe:
+    # DO NOT use fc40-unsafe as a repo-bundle in your eext.yaml
+    # unless you know what you're doing. Use fc40-snapshot instead because this
+    # will ensure build reproducibility.
+    # fc40-unsafe is used by the eext team for experiments.
+
+    gpgcheck: true
+    gpgkey: file:///usr/share/distribution-gpg-keys/fedora/RPM-GPG-KEY-fedora-40-primary
+
+    # fc40 publishes i686 RPMS in x86_64 repo. This ensures that we point to the x86_64 repo
+    # when target is i686.
+    use-base-arch: true
+    baseurl: "{{.Host}}/artifactory/eext-fedora-linux/{{.RepoName}}/{{.Version}}/Everything/{{.Arch}}/os"
+    repo:
+      releases:
+        enabled: true
+    version-labels:
+      default: 40
+    priority: 3
+#---------------------------------------------------------------------------------------------

--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -23,6 +23,7 @@ repo-bundle:
         enabled: false
     version-labels:
       default: 9.3
+    priority: 2
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -43,6 +44,7 @@ repo-bundle:
       # The eext team is responsible for creating these snapshots.
       # default points to the latest such snapshot.
       default: v20240522-1
+    priority: 2
 # --------------------------------------------------------------------------------------------
 
 # ********************************************************************************************
@@ -57,7 +59,7 @@ repo-bundle:
 
     gpgcheck: true
     gpgkey: file:///usr/share/distribution-gpg-keys/alma/RPM-GPG-KEY-AlmaLinux-9
-    baseurl: '{{.Host}}/artifactory/eext-snapshots-local/el9/{{.Version}}/9/{{.RepoName}}/{{.Arch}}/os'
+    baseurl: "{{.Host}}/artifactory/eext-snapshots-local/el9/{{.Version}}/9/{{.RepoName}}/{{.Arch}}/os"
     repo:
       AppStream:
         enabled: true
@@ -69,6 +71,7 @@ repo-bundle:
         enabled: false
       extras:
         enabled: false
+    priority: 2
 #---------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -98,6 +101,7 @@ repo-bundle:
       # default=9 always points to upstream latest dot release 9.x,
       # which upstream updates regularly.
       default: 9
+    priority: 2
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -127,6 +131,7 @@ repo-bundle:
       # default always points to upstream latest dot release 9.x's beta version,
       # which upstream updates regularly.
       default: 9.4-beta
+    priority: 2
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -151,6 +156,7 @@ repo-bundle:
     version-labels:
       # default always points to upstream stable repo which receives updates.
       default: 9
+    priority: 2
 # --------------------------------------------------------------------------------------------
 
 # --------------------------------------------------------------------------------------------
@@ -174,4 +180,5 @@ repo-bundle:
     version-labels:
       # default always points to upstream next/beta repo which receives updates.
       default: 9
+    priority: 2
 # --------------------------------------------------------------------------------------------

--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -153,6 +153,38 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 			},
 			defaultVersion: "9",
 		},
+		"fc40-unsafe": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"releases": "%s/artifactory/%s/releases/%s/Everything/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-fedora-linux",
+				"x86_64":  "eext-fedora-linux",
+				"aarch64": "eext-fedora-linux",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "x86_64", // baseArch
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "40",
+		},
+		"fc40-snapshot": ExpectedDefaultRepoBundle{
+			repoToURLFormatString: map[string]string{
+				"releases": "%s/artifactory/%s/fc40/default/releases/%s/Everything/%s/os",
+			},
+			archToArtifactoryRepo: map[string]string{
+				"i686":    "eext-snapshots-local",
+				"x86_64":  "eext-snapshots-local",
+				"aarch64": "eext-snapshots-local",
+			},
+			archToURLFormatArch: map[string]string{
+				"i686":    "x86_64", // baseArch
+				"x86_64":  "x86_64",
+				"aarch64": "aarch64",
+			},
+			defaultVersion: "40",
+		},
 	}
 
 	t.Log("Testing expected defaults")

--- a/dnfconfig/testData/sample-dnfconfig.yaml
+++ b/dnfconfig/testData/sample-dnfconfig.yaml
@@ -12,6 +12,7 @@ repo-bundle:
     version-labels:
       latest: 999
       default: 1
+    priority: 2
   bundle2:
     baseurl: "{{.Host}}/bundle2-{{.Version}}/{{.RepoName}}/{{.Arch}}/"
     use-base-arch: true
@@ -23,3 +24,4 @@ repo-bundle:
     version-labels:
       latest: 999
       default: 1
+    priority: 3

--- a/impl/testData/dnfconfig.yaml
+++ b/impl/testData/dnfconfig.yaml
@@ -15,6 +15,7 @@ repo-bundle:
         enabled: true
     version-labels:
       default: v1
+    priority: 2
   bundle-boo2:
     baseurl: "{{.Host}}/boo2-{{.Version}}/{{.RepoName}}/{{.Arch}}/"
     use-base-arch: true
@@ -24,6 +25,7 @@ repo-bundle:
     version-labels:
       default: v1
       latest: v3
+    priority: 2
   bundle-boo3:
     baseurl: "{{.Host}}/boo3-{{.Version}}/{{.RepoName}}/{{.Arch}}/"
     repo:
@@ -32,3 +34,4 @@ repo-bundle:
     version-labels:
       default: v1
       latest: v3
+    priority: 3

--- a/impl/testData/expected-mock.cfg
+++ b/impl/testData/expected-mock.cfg
@@ -79,7 +79,7 @@ baseurl = https://foo.org/boo1-v1/repo-roo12/x86_64/
 enabled = 0
 gpgcheck = 1
 gpgkey = file:///keyfile
-priority = 2
+priority = 3
 
 [repo-roo13]
 name = repo-roo13

--- a/impl/testData/manifest-with-deps.yaml
+++ b/impl/testData/manifest-with-deps.yaml
@@ -13,6 +13,7 @@ package:
               exclude: "roo1-rpm.rpm"
             repo-roo12:
               enabled: false
+              priority: 3
         - name: bundle-boo2
           version: v2
         - name: bundle-boo2

--- a/impl/testData/manifest.yaml
+++ b/impl/testData/manifest.yaml
@@ -13,6 +13,7 @@ package:
               exclude: "roo1-rpm.rpm"
             repo-roo12:
               enabled: false
+              priority: 3
         - name: bundle-boo2
           version: v2
         - name: bundle-boo2

--- a/manifest/testData/sampleManifest1.yaml
+++ b/manifest/testData/sampleManifest1.yaml
@@ -15,6 +15,7 @@ package:
             rfoo:
               enabled: true
               exclude: "rfoo.rpm"
+              priority: 4
         - name: bar
   - name: tcpdump
     upstream-sources:


### PR DESCRIPTION
Few eext packages have dependency on fedora distribution. We can resolve the dependencies by creating eext packages for these package, but that will result in unnecessary creation of a lot of upstream packages.
Instead we intend to provide these dependencies through a fc40 repo snapshot. We have created 2 new repo-bundles:
1. fc40-unsafe: upstream clone which will pull in the required dependencies
2. fc40-snapshot: local snapshot for eext packages to refer to for dependencies

As part of this feature, we also need to add priority to each repo-bundle, since we want fedora repos to have lowest priority (fc40 should be the last resort to satisfy a dependency, if we find it elsewhere, get it from there). We define repo-bundle level priority in dnfconfig.yaml and allow users to override priority at repo level in their respective eext.yaml.