### PR TITLE
eext.yaml sanity check

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -148,7 +148,7 @@ type Manifest struct {
 
 func (m Manifest) sanityCheck() error {
 	allowedPkgTypes := []string{"srpm", "unmodified-srpm", "tarball", "standalone"}
-
+	allowedArchs := []string{"i686", "x86_64"}
 	for _, pkgSpec := range m.Package {
 		if pkgSpec.Name == "" {
 			return fmt.Errorf("Package name not specified in manifest")
@@ -203,6 +203,20 @@ func (m Manifest) sanityCheck() error {
 					pkgSpec.Name)
 			}
 		}
+
+		for pkgName, pkgPath := range pkgSpec.Build.Generator.ExternalDependencies {
+			if pkgPath == "" {
+				return fmt.Errorf("Empty repo path in yaml:external-dependencies for package %s",
+					pkgName)
+			}
+		}
+
+		for arch := range pkgSpec.Build.Generator.Multilib {
+			if !slices.Contains(allowedArchs, arch) {
+				return fmt.Errorf("Architecture %s not suported", arch)
+			}
+		}
+
 	}
 	return nil
 }

--- a/manifest/manifest_test.go
+++ b/manifest/manifest_test.go
@@ -67,6 +67,16 @@ func TestManifestNegative(t *testing.T) {
 			ManifestFile: "sampleManifest3.yaml",
 			ExpectedErr:  "Conflicting signatures for Build in package tcpdump, provide full-url or source-bundle",
 		},
+		"testEmptyExtDepsRepoPath": manifestTestVariant{
+			TestPkg:      "pkg4",
+			ManifestFile: "sampleManifest4.yaml",
+			ExpectedErr:  "Empty repo path in yaml:external-dependencies for package crypto-policies",
+		},
+		"testUnsupportedArch": manifestTestVariant{
+			TestPkg:      "pkg5",
+			ManifestFile: "sampleManifest5.yaml",
+			ExpectedErr:  "Architecture aarch64 not suported",
+		},
 	}
 	for testName, variant := range testCases {
 		t.Logf("%s: Copy sample manifest to test directory", testName)

--- a/manifest/testData/sampleManifest4.yaml
+++ b/manifest/testData/sampleManifest4.yaml
@@ -1,0 +1,20 @@
+---
+package:
+  - name: openssl
+    upstream-sources:
+      - source-bundle:
+          name: srpm
+          override:
+            version: 3.0.7-27.el9
+    type: srpm
+    build:
+      repo-bundle:
+        - name: el9
+      dependencies:
+        all:
+          - crypto-policies
+          - openssl3-fips
+      eextgen:
+        external-dependencies:
+          crypto-policies:
+          openssl3-fips: code.arista.io/eos/eext/openssl3-fips/

--- a/manifest/testData/sampleManifest5.yaml
+++ b/manifest/testData/sampleManifest5.yaml
@@ -1,0 +1,23 @@
+---
+package:
+  - name: openssl
+    upstream-sources:
+      - source-bundle:
+          name: srpm
+          override:
+            version: 3.0.7-27.el9
+    type: srpm
+    build:
+      repo-bundle:
+        - name: el9
+      dependencies:
+        all:
+          - crypto-policies
+          - openssl3-fips
+      eextgen:
+        multilib:
+          aarch64:
+            other-arch:
+              patterns:
+                - "openssl-devel*.rpm"
+              remove: True


### PR DESCRIPTION
If repo path for any package under extern dependencies is left empty it would throw an error. If unsupported architecture is provided in multilib it would throw an error. These issues are handled in this commit. Sanity check is added for eextgen in eext.yaml file.
- Check added to catch empty repo paths for a package in yaml:"external-dependencies"
- Check added to catch unsupported architectures in yaml:"multilib"