### PR TITLE
Update artifactory repos for eext boostrapping

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -58,7 +58,7 @@ images:
             BOOTSTRAP_PATH: eext-sources/bootstrap/CentOS-Stream
             BOOTSTRAP_FILE: CentOS-Stream-Container-Base-9-20240715.0
             BOOTSTRAP_EXTENSION: tar.xz
-            DNF_DISTRO_REPO: alma-vault
+            DNF_DISTRO_REPO: eext-alma-vault
             DNF_DISTRO_REPO_VERSION: "9.3"
             DNF_EPEL_REPO: eext-snapshots-local/epel9
             DNF_EPEL_REPO_SNAPSHOT_VERSION: v20240127-1


### PR DESCRIPTION
Make bootstrapping fetch from eext-alma-vault artifactory remote repository instead of alma-vault. alma-vault is used my many other clients not just eext. There's no guarantee for it's caches being preserved. However, eext-alma-vault is used only by eext and we've plans to backup it's caches after each release to capture the dependencies of both the eext tool and also each eext package.