### PR TITLE
Various test improvements

### DIFF
--- a/barney.yaml
+++ b/barney.yaml
@@ -330,11 +330,11 @@ images:
     units:
       - floor: .%eext-testfloor
         build: |
-          go test code.arista.io/eos/tools/eext/dnfconfig
-          go test code.arista.io/eos/tools/eext/srcconfig
-          go test code.arista.io/eos/tools/eext/manifest
-          go test code.arista.io/eos/tools/eext/impl
-          go test code.arista.io/eos/tools/eext/cmd -tags privileged
+          go test code.arista.io/eos/tools/eext/dnfconfig -tags containerized
+          go test code.arista.io/eos/tools/eext/srcconfig -tags containerized
+          go test code.arista.io/eos/tools/eext/manifest -tags containerized
+          go test code.arista.io/eos/tools/eext/impl -tags containerized
+          go test code.arista.io/eos/tools/eext/cmd -tags "privileged containerized"
           go vet code.arista.io/eos/tools/eext/...
           test -z "$(gofmt -l .)"
 

--- a/barney.yaml
+++ b/barney.yaml
@@ -334,7 +334,6 @@ images:
           go test code.arista.io/eos/tools/eext/srcconfig
           go test code.arista.io/eos/tools/eext/manifest
           go test code.arista.io/eos/tools/eext/impl
-          go test code.arista.io/eos/tools/eext/cmd
           go test code.arista.io/eos/tools/eext/cmd -tags privileged
           go vet code.arista.io/eos/tools/eext/...
           test -z "$(gofmt -l .)"

--- a/cmd/create_srpm_test.go
+++ b/cmd/create_srpm_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Arista Networks, Inc.  All rights reserved.
 // Arista Networks, Inc. Confidential and Proprietary.
 
+//go:build containerized
+
 package cmd
 
 import (

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -2,7 +2,6 @@
 // Arista Networks, Inc. Confidential and Proprietary.
 
 //go:build privileged
-// +build privileged
 
 package cmd
 

--- a/cmd/mock_test.go
+++ b/cmd/mock_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Arista Networks, Inc.  All rights reserved.
 // Arista Networks, Inc. Confidential and Proprietary.
 
-//go:build privileged
+//go:build privileged && containerized
 
 package cmd
 

--- a/impl/create_srpm_from_git_test.go
+++ b/impl/create_srpm_from_git_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
 // Arista Networks, Inc. Confidential and Proprietary.
 
+//go:build containerized
+
 package impl
 
 import (

--- a/impl/create_srpm_from_unmodified_srpm_test.go
+++ b/impl/create_srpm_from_unmodified_srpm_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2024 Arista Networks, Inc.  All rights reserved.
 // Arista Networks, Inc. Confidential and Proprietary.
 
+//go:build containerized
+
 package impl
 
 import (

--- a/impl/setupDeps_test.go
+++ b/impl/setupDeps_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Arista Networks, Inc.  All rights reserved.
 // Arista Networks, Inc. Confidential and Proprietary.
 
+//go:build containerized
+
 package impl
 
 import (


### PR DESCRIPTION
This PR brings a handful of improvements to how tests are run in eext.

1. afecec044f9291a91487eb6bc4451202a3a82276 remove redundant build tag
We require golang 1.18, and the tag that's removed by this patch was needed for golang versions older than 1.17.
2. f25fcba2bf72f0d35a64fa8a11f071037e8cef85 remove double running of the tests in `cmd/`
    `go test dir -tags=sometag` runs the tests tagged with "sometag", but also runs **all the untagged** tests, thus, having both:
    * `go test code.arista.io/eos/tools/eext/cmd`
    * `go test code.arista.io/eos/tools/eext/cmd -tags privileged`
    doesn't bring any value. The elapsed time spent testing is effectively halved.
3.   121baa9d5bd9bdd3e0059f25055f2873c8942f58 mark some tests as "containerized" and make barney run them.
This commit brings a distinction between unit/code tests and a production-like tests. The latter do destructive changes to the system they're being run on and they should be run in container, thus the  "containerized" tag.
Barney already run all the tests, including the destructive ones, so this patch also makes sure that barney runs the newly marked tests.
Overall this patch enables developers to run the normal unit and integration tests without having to reach to Barney to iterate.
The follow-up patch would be to mock all the system tools called by the tests and mocking them inside the code, creating the non-destructive alternative set that could be run on any machine.

The Barney test run go test [output is here](https://bsy.infra.corp.arista.io/job/J12410147b45c3d720f90b5b784f543c288f3ecafde8cd2b5a930839ed99dd4b5/log).