### PR TITLE
explicitly pass config path when reading dnf config

### DIFF
--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -19,11 +19,10 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 	repoHost := "https://artifactory.infra.corp.arista.io"
 	viper.Set("DnfRepoHost",
 		"https://artifactory.infra.corp.arista.io")
-	viper.Set("DnfConfigFile", "../configfiles/dnfconfig.yaml")
 	defer viper.Reset()
 
 	t.Log("Testing YAML syntax")
-	dnfConfig, loadErr := LoadDnfConfig()
+	dnfConfig, loadErr := LoadDnfConfig("../configfiles/dnfconfig.yaml")
 	require.NoError(t, loadErr)
 	require.NotNil(t, dnfConfig)
 	t.Log("YAML syntax ok")

--- a/dnfconfig/dnfconfig.go
+++ b/dnfconfig/dnfconfig.go
@@ -190,8 +190,7 @@ func (b *DnfRepoBundleConfig) GetDnfRepoParams(
 // Enabled computes enabled flags for a particular repo
 // LoadDnfConfig loads the dnf repo config file, parses it and
 // returns the data structure
-func LoadDnfConfig() (*DnfConfig, error) {
-	cfgPath := viper.GetString("DnfConfigFile")
+func LoadDnfConfig(cfgPath string) (*DnfConfig, error) {
 	_, statErr := os.Stat(cfgPath)
 	if statErr != nil {
 		if os.IsNotExist(statErr) {

--- a/dnfconfig/dnfconfig_test.go
+++ b/dnfconfig/dnfconfig_test.go
@@ -21,12 +21,11 @@ func TestRepoConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
-	viper.Set("DnfConfigFile", "testData/sample-dnfconfig.yaml")
 	viper.Set("DnfRepoHost", "http://foo.org")
 	defer viper.Reset()
 
 	t.Log("Testing Load")
-	dnfConfig, loadErr := LoadDnfConfig()
+	dnfConfig, loadErr := LoadDnfConfig("testData/sample-dnfconfig.yaml")
 	require.NoError(t, loadErr)
 	require.NotNil(t, dnfConfig)
 	require.Contains(t, dnfConfig.DnfRepoBundleConfig, "bundle1")

--- a/impl/mock.go
+++ b/impl/mock.go
@@ -358,8 +358,8 @@ func Mock(repo string, pkg string, arch string, extraArgs MockExtraCmdlineArgs) 
 		util.ErrPrefix("mockBuilder: ")); err != nil {
 		return err
 	}
-
-	dnfConfig, dnfConfigErr := dnfconfig.LoadDnfConfig()
+	cfgPath := viper.GetString("DnfConfigFile")
+	dnfConfig, dnfConfigErr := dnfconfig.LoadDnfConfig(cfgPath)
 	if dnfConfigErr != nil {
 		return dnfConfigErr
 	}

--- a/impl/mock_cfg_test.go
+++ b/impl/mock_cfg_test.go
@@ -69,7 +69,8 @@ func testMockConfig(t *testing.T, chained bool) {
 	require.NotNil(t, manifestObj)
 
 	t.Log("Load dnfconfig.yaml")
-	dnfConfig, loadErr := dnfconfig.LoadDnfConfig()
+	cfgPath := viper.GetString("DnfConfigFile")
+	dnfConfig, loadErr := dnfconfig.LoadDnfConfig(cfgPath)
 	require.NoError(t, loadErr)
 	require.NotNil(t, dnfConfig)
 


### PR DESCRIPTION
This is the first patch in series to reduce the reliance on the global, implic viper object. Making path an argument to the loading function this patch enables us to do a simple dependency injection in tests instead of having to set (and then reset via defer) the value in the global viper object.