### PR TITLE
Enable local testing using docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,18 +15,18 @@ USER root
 RUN dnf install -y golang-1.21.* && dnf clean all
 RUN mkdir -p /src/code.arista.io/eos/tools/eext && mkdir -p /usr/bin
 WORKDIR /src/code.arista.io/eos/tools/eext
-COPY ./go.mod ./
-COPY ./go.sum ./
 COPY ./*.go ./
 COPY ./cmd/ cmd/
-COPY ./impl/ impl/
-COPY ./util/ util/
-COPY ./testutil/ testutil/
-COPY ./manifest/ manifest/
-COPY ./dnfconfig/ dnfconfig/
-COPY ./srcconfig/ srcconfig/
 COPY ./configfiles/ configfiles/
-COPY ./pki /pki
+COPY ./dnfconfig/ dnfconfig/
+COPY ./go.mod ./
+COPY ./go.sum ./
+COPY ./impl/ impl/
+COPY ./manifest/ manifest/
+COPY ./pki/ pki/
+COPY ./srcconfig/ srcconfig/
+COPY ./testutil/ testutil/
+COPY ./util/ util/
 RUN go mod download && go build -o /usr/bin/eext
 
 FROM base as deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ COPY ./testutil/ testutil/
 COPY ./manifest/ manifest/
 COPY ./dnfconfig/ dnfconfig/
 COPY ./srcconfig/ srcconfig/
+COPY ./configfiles/ configfiles/
+COPY ./pki /pki
 RUN go mod download && go build -o /usr/bin/eext
 
 FROM base as deploy


### PR DESCRIPTION
Add missing files that prevented the `go test` from passing.
This enables local testing, including testing that uses internet and runs a production-like scenarios.
The tests can be run with:
```bash
docker run --cap-add=SYS_ADMIN  -it builder-image go test -v ./... -tags="privileged containerized"
```
This PR also sorts the COPY section for the builder image definition in the dockerfile. Note that this PR is based on the [PR #130](https://github.com/aristanetworks/eos-external-tools/pull/130) which is yet to land.