### PR TITLE
Add verbose flag to mock command

### DIFF
--- a/impl/mock.go
+++ b/impl/mock.go
@@ -182,6 +182,8 @@ func (bldr *mockBuilder) mockArgs(extraArgs []string) []string {
 	}
 	if util.GlobalVar.Quiet {
 		baseArgs = append(baseArgs, "--quiet")
+	} else {
+		baseArgs = append(baseArgs, "--verbose")
 	}
 
 	mockArgs := append(baseArgs, extraArgs...)


### PR DESCRIPTION
Barney builds have introduced an idle timeout; if a build step doesn't output logs to the console for 30 minutes, it cancels the build. In eext case, 'eext mock' is the barney build step which at time can take a long time to complete. Previously, we were only redirecting stdout and stderr to barney, not the entire logs. This was causing some eext builds to get timed out, since no ouptut was seen for > 30 min. Hence we add a '--verbose' flag to the mock step of eext to ensure that builds are not cancelled due to idle timeout.