### PR TITLE
Support for git-worktree

### DIFF
--- a/impl/create_srpm.go
+++ b/impl/create_srpm.go
@@ -90,8 +90,8 @@ func (bldr *srpmBuilder) fetchUpstream() error {
 		upstreamSrcType := bldr.pkgSpec.Type
 		var upstreamSrc *upstreamSrcSpec
 		var err error
-		if upstreamSrcType == "git-upstream" {
-			upstreamSrc, err = bldr.getUpstreamSourceForGit(upstreamSrcFromManifest, downloadDir)
+		if upstreamSrcType == "git-upstream" || upstreamSrcType == "git-worktree" {
+			upstreamSrc, err = bldr.getUpstreamSourceForGit(upstreamSrcFromManifest, upstreamSrcType, downloadDir)
 		} else {
 			upstreamSrc, err = bldr.getUpstreamSourceForOthers(upstreamSrcFromManifest, downloadDir)
 		}
@@ -162,7 +162,7 @@ func (bldr *srpmBuilder) verifyUpstream() error {
 		if err := bldr.verifyUpstreamSrpm(); err != nil {
 			return err
 		}
-	} else if bldr.pkgSpec.Type == "git-upstream" {
+	} else if bldr.pkgSpec.Type == "git-upstream" || bldr.pkgSpec.Type == "git-worktree" {
 		for _, upstreamSrc := range bldr.upstreamSrc {
 			if !upstreamSrc.skipSigCheck {
 				err := verifyGitSignature(upstreamSrc.pubKeyPath, upstreamSrc.gitSpec, bldr.errPrefix)
@@ -236,7 +236,7 @@ func (bldr *srpmBuilder) setupRpmbuildTreeSrpm() error {
 // also checks tarball signature
 func (bldr *srpmBuilder) setupRpmbuildTreeNonSrpm() error {
 
-	supportedTypes := []string{"tarball", "standalone", "git-upstream"}
+	supportedTypes := []string{"tarball", "standalone", "git-upstream", "git-worktree"}
 	if !slices.Contains(supportedTypes, bldr.pkgSpec.Type) {
 		panic(fmt.Sprintf("%ssetupRpmbuildTreeNonSrpm called for unsupported type %s",
 			bldr.errPrefix, bldr.pkgSpec.Type))
@@ -345,7 +345,7 @@ func (bldr *srpmBuilder) setupRpmbuildTree() error {
 			return err
 		}
 	} else if bldr.pkgSpec.Type == "tarball" || bldr.pkgSpec.Type == "standalone" ||
-		bldr.pkgSpec.Type == "git-upstream" {
+		bldr.pkgSpec.Type == "git-upstream" || bldr.pkgSpec.Type == "git-worktree" {
 		if err := bldr.setupRpmbuildTreeNonSrpm(); err != nil {
 			return err
 		}

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -153,7 +153,7 @@ type Manifest struct {
 }
 
 func (m Manifest) sanityCheck() error {
-	allowedPkgTypes := []string{"srpm", "unmodified-srpm", "tarball", "standalone", "git-upstream"}
+	allowedPkgTypes := []string{"srpm", "unmodified-srpm", "tarball", "standalone", "git-upstream", "git-worktree"}
 
 	for _, pkgSpec := range m.Package {
 		if pkgSpec.Name == "" {
@@ -190,10 +190,10 @@ func (m Manifest) sanityCheck() error {
 		}
 
 		for _, upStreamSrc := range pkgSpec.UpstreamSrc {
-			if pkgSpec.Type == "git-upstream" {
+			if pkgSpec.Type == "git-upstream" || pkgSpec.Type == "git-worktree" {
 				specifiedUrl := (upStreamSrc.GitBundle.Url != "")
 				specifiedRevision := (upStreamSrc.GitBundle.Revision != "")
-				if !specifiedUrl {
+				if !specifiedUrl && pkgSpec.Type == "git-upstream" {
 					return fmt.Errorf("please provide the url for git repo of package %s", pkgSpec.Name)
 				}
 				if !specifiedRevision {


### PR DESCRIPTION
We have currently enabled support to use an upstream git repo as a source for eext. However there are cases where developers have an internal repo (forked from upstream) that they want to use as the source. We hence add support for 'git-worktree'.
Developers can add an 'eext.yaml' file in their repo (no need to create an eext specific repo), along with the .spec file to build the package. eext will take care of creating the source tarball from the git repo, and generate the necessary (S)RPMs.