### PR TITLE
root command to list unverified upstream sources

### DIFF
--- a/cmd/list_unverified_sources.go
+++ b/cmd/list_unverified_sources.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package cmd
+
+import (
+	"code.arista.io/eos/tools/eext/impl"
+	"github.com/spf13/cobra"
+)
+
+// listUnverifiedSourcesCmd represents the list-unverified-sources command
+var listUnverifiedSourcesCmd = &cobra.Command{
+	Use:   "list-unverified-sources",
+	Short: "list unverified upstream sources",
+	Long: `Checks for the upstream sources within package which don't 
+have a valid signature check return prints the upstreamSrc
+to stdout.`,
+	Args: cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		repo, _ := cmd.Flags().GetString("repo")
+		pkg, _ := cmd.Flags().GetString("package")
+		err := impl.ListUnverifiedSources(repo, pkg)
+		return err
+	},
+}
+
+func init() {
+	listUnverifiedSourcesCmd.Flags().StringP("repo", "r", "", "Repository name (OPTIONAL)")
+	listUnverifiedSourcesCmd.Flags().StringP("package", "p", "", "specify package name (REQUIRED)")
+	listUnverifiedSourcesCmd.MarkFlagRequired("package")
+	rootCmd.AddCommand(listUnverifiedSourcesCmd)
+}

--- a/impl/list_unverified_sources.go
+++ b/impl/list_unverified_sources.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package impl
+
+import (
+	"fmt"
+
+	"code.arista.io/eos/tools/eext/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// fetch upstream sources from manifest
+func getUpstreamSrcsWithSkipCheck(upstreamSrcManifest []manifest.UpstreamSrc) []manifest.UpstreamSrc {
+	upstreamSrcs := []manifest.UpstreamSrc{}
+
+	for _, upstreamSrcFromManifest := range upstreamSrcManifest {
+		if upstreamSrcFromManifest.Signature.SkipCheck {
+			upstreamSrcs = append(upstreamSrcs, upstreamSrcFromManifest)
+		}
+	}
+
+	return upstreamSrcs
+}
+
+// ListUnverifiedSources lists all the upstream sources within a package
+// which do not have valid signature check.
+func ListUnverifiedSources(repo string, pkg string) error {
+	repoManifest, loadManifestErr := manifest.LoadManifest(repo)
+	if loadManifestErr != nil {
+		return loadManifestErr
+	}
+
+	upstreamSources := []manifest.UpstreamSrc{}
+	pkgFound := false
+	for _, pkgSpec := range repoManifest.Package {
+		if pkgSpec.Name == pkg {
+			pkgFound = true
+			upstreamSources = getUpstreamSrcsWithSkipCheck(pkgSpec.UpstreamSrc)
+			break
+		}
+	}
+
+	if !pkgFound {
+		return fmt.Errorf("impl.ListUnVerifiedSources: '%s' package is not part of this repo", pkg)
+	}
+
+	if len(upstreamSources) != 0 {
+		yamlUpstreamSources, err := yaml.Marshal(upstreamSources)
+		if err != nil {
+			return fmt.Errorf("impl.ListUnVerifiedSources: '%s' unmarshaling yaml", err)
+		}
+		fmt.Println(string(yamlUpstreamSources))
+	}
+	return nil
+}

--- a/impl/list_unverified_sources_test.go
+++ b/impl/list_unverified_sources_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 Arista Networks, Inc.  All rights reserved.
+// Arista Networks, Inc. Confidential and Proprietary.
+
+package impl
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func readExpectedOuptut(t *testing.T, filePath string) string {
+	fileContent, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatalf("impl.TestListUnverifiedSources: errored failed while reading %s file", filePath)
+	}
+	return string(fileContent)
+}
+
+func TestListUnverifiedSources(t *testing.T) {
+	cwd, _ := os.Getwd()
+	repo := filepath.Join(cwd, "testData/unverified-src")
+
+	testpkgs := map[string]string{
+		"foo1": "",
+		"foo2": readExpectedOuptut(t, "testData/unverified-src/list-unverified-sources.txt"),
+	}
+
+	var r, w, rescueStdout *(os.File)
+	var buffer bytes.Buffer
+
+	for pkg, expectedOutput := range testpkgs {
+		rescueStdout = os.Stdout
+		r, w, _ = os.Pipe()
+		os.Stdout = w
+
+		ListUnverifiedSources(repo, pkg)
+
+		w.Close()
+		buffer.ReadFrom(r)
+		outputGot := buffer.String()
+		os.Stdout = rescueStdout
+
+		require.Equal(t, expectedOutput, outputGot)
+	}
+
+	t.Log("TestListUnverifiedSources test Passed")
+}
+
+func TestListUnverifiedSourcesFail(t *testing.T) {
+	cwd, _ := os.Getwd()
+	repo := filepath.Join(cwd, "testData/unverified-src")
+
+	err := ListUnverifiedSources(repo, "foo3")
+	require.Error(t, err)
+
+	t.Log("TestListUnverifiedSourcesFail test Passed")
+}

--- a/impl/testData/unverified-src/eext.yaml
+++ b/impl/testData/unverified-src/eext.yaml
@@ -1,0 +1,25 @@
+---
+package:
+  - name: foo1
+    upstream-sources:
+      - source-bundle:
+          name: srpm
+          override:
+            version: 1.7.7-1.fc40
+    type: srpm
+    build:
+      repo-bundle:
+        - name: el9
+
+  - name: foo2
+    upstream-sources:
+      - source-bundle:
+          name: srpm
+          override:
+            version: 1.7.7-1.fc40
+        signature:
+          skip-check: true
+    type: srpm
+    build:
+      repo-bundle:
+        - name: el9

--- a/impl/testData/unverified-src/list-unverified-sources.txt
+++ b/impl/testData/unverified-src/list-unverified-sources.txt
@@ -1,0 +1,18 @@
+- source-bundle:
+    name: srpm
+    override:
+        version: 1.7.7-1.fc40
+        src-suffix: ""
+        sig-suffix: ""
+  full-url: ""
+  git:
+    url: ""
+    revision: ""
+  signature:
+    skip-check: true
+    detached-sig:
+        full-url: ""
+        public-key: ""
+        on-uncompressed: false
+  sha256: ""
+


### PR DESCRIPTION
New root command is designed to list all upstream sources with the `skip-check` flag set to `true`.
- If `-p <package>` is specified, it lists unverified sources for the specified package.
- If <package> not forund in repo, error is thrown
The output is written to stdout
This will enable better tracking of unverified sources.