### PR TITLE
Upgrade dependencies to latest versions

### DIFF
--- a/configfiles/dnfconfig.yaml
+++ b/configfiles/dnfconfig.yaml
@@ -22,7 +22,7 @@ repo-bundle:
       extras:
         enabled: false
     version-labels:
-      default: 9.3
+      default: 9.4
     priority: 2
   # --------------------------------------------------------------------------------------------
 
@@ -43,7 +43,7 @@ repo-bundle:
       # Each version points to a timestamped snapshot of the repo cache of the epel9-unsafe repo.
       # The eext team is responsible for creating these snapshots.
       # default points to the latest such snapshot.
-      default: v20240522-1
+      default: v20250107-1
     priority: 2
   # --------------------------------------------------------------------------------------------
 
@@ -149,7 +149,7 @@ repo-bundle:
     version-labels:
       # default always points to upstream latest dot release 9.x's beta version,
       # which upstream updates regularly.
-      default: 9.4-beta
+      default: 9.5-beta
     priority: 2
   # --------------------------------------------------------------------------------------------
 

--- a/dnfconfig/defaultconfig_test.go
+++ b/dnfconfig/defaultconfig_test.go
@@ -51,7 +51,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "9.3",
+			defaultVersion: "9.4",
 		},
 		"el9-snapshot": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{
@@ -102,7 +102,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "9.4-beta",
+			defaultVersion: "9.5-beta",
 		},
 		"epel9": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{
@@ -118,7 +118,7 @@ func TestDefaultDnfRepoConfig(t *testing.T) {
 				"x86_64":  "x86_64",
 				"aarch64": "aarch64",
 			},
-			defaultVersion: "v20240522-1",
+			defaultVersion: "v20250107-1",
 		},
 		"epel9-unsafe": ExpectedDefaultRepoBundle{
 			repoToURLFormatString: map[string]string{


### PR DESCRIPTION
With release of Alma 9.5, we want to upgrade the eext package dependencies to the latest vaulted versions of the corresponding rpms. This ensures eext packages are using the latest rpms to build. We update the el9 repo to point to 9.4 (vaulted), and create an epel repo snapshot containing the updated versions of the rpms.