### PR TITLE
Don't run build-prep by default for create-srpm

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -20,10 +20,10 @@ var buildCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, _ := cmd.Flags().GetString("repo")
 		pkg, _ := cmd.Flags().GetString("package")
-		skipBuildPrep, _ := cmd.Flags().GetBool("skip-build-prep")
+		doBuildPrep, _ := cmd.Flags().GetBool("do-build-prep")
 		noCheck, _ := cmd.Flags().GetBool("nocheck")
 		extraCreateSrpmArgs := impl.CreateSrpmExtraCmdlineArgs{
-			SkipBuildPrep: skipBuildPrep,
+			DoBuildPrep: doBuildPrep,
 		}
 		extraMockArgs := impl.MockExtraCmdlineArgs{
 			NoCheck: noCheck,
@@ -35,7 +35,9 @@ var buildCmd = &cobra.Command{
 func init() {
 	buildCmd.Flags().StringP("repo", "r", "", "Repository name (OPTIONAL)")
 	buildCmd.Flags().StringP("package", "p", "", "package name (OPTIONAL)")
-	buildCmd.Flags().Bool("skip-build-prep", false, "Skips build-prep during createSrpm for cases where build-prep requires dependencies not in container (OPTIONAL)")
+	buildCmd.Flags().Bool("skip-build-prep", false, "DEPRECATED. No-op")
+	buildCmd.Flags().MarkHidden("skip-build-prep")
+	buildCmd.Flags().Bool("do-build-prep", false, "Runs build-prep on the created SRPM to make sure patches apply cleanly (OPTIONAL)")
 	buildCmd.Flags().Bool("nocheck", false, "Pass --nocheck to rpmbuild (OPTIONAL)")
 	rootCmd.AddCommand(buildCmd)
 }

--- a/cmd/create_srpm.go
+++ b/cmd/create_srpm.go
@@ -23,9 +23,9 @@ In situations where multiple SRPMs need to be built in dependency order, the man
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repo, _ := cmd.Flags().GetString("repo")
 		pkg, _ := cmd.Flags().GetString("package")
-		skipBuildPrep, _ := cmd.Flags().GetBool("skip-build-prep")
+		doBuildPrep, _ := cmd.Flags().GetBool("do-build-prep")
 		extraArgs := impl.CreateSrpmExtraCmdlineArgs{
-			SkipBuildPrep: skipBuildPrep,
+			DoBuildPrep: doBuildPrep,
 		}
 		err := impl.CreateSrpm(repo, pkg, extraArgs, selectExecutor())
 		return err
@@ -35,6 +35,8 @@ In situations where multiple SRPMs need to be built in dependency order, the man
 func init() {
 	createSrpmCmd.Flags().StringP("repo", "r", "", "Repository name (OPTIONAL)")
 	createSrpmCmd.Flags().StringP("package", "p", "", "package name (OPTIONAL)")
-	createSrpmCmd.Flags().Bool("skip-build-prep", false, "Skips build-prep for cases where build-prep requires dependencies not in container(OPTIONAL)")
+	createSrpmCmd.Flags().Bool("skip-build-prep", false, "DEPRECATED. No-op")
+	createSrpmCmd.Flags().MarkHidden("skip-build-prep")
+	createSrpmCmd.Flags().Bool("do-build-prep", false, "Runs build-prep on the created SRPM to make sure patches apply cleanly (OPTIONAL)")
 	rootCmd.AddCommand(createSrpmCmd)
 }

--- a/impl/create_srpm.go
+++ b/impl/create_srpm.go
@@ -30,7 +30,7 @@ type upstreamSrcSpec struct {
 type srpmBuilder struct {
 	pkgSpec       *manifest.Package
 	repo          string
-	skipBuildPrep bool
+	doBuildPrep   bool
 	errPrefixBase util.ErrPrefix
 	errPrefix     util.ErrPrefix
 	upstreamSrc   []upstreamSrcSpec
@@ -40,7 +40,7 @@ type srpmBuilder struct {
 
 // CreateSrpmExtraCmdlineArgs is a bundle of extra args for impl.CreateSrpm
 type CreateSrpmExtraCmdlineArgs struct {
-	SkipBuildPrep bool
+	DoBuildPrep bool
 }
 
 func (bldr *srpmBuilder) log(format string, a ...any) {
@@ -527,7 +527,7 @@ func (bldr *srpmBuilder) runStages() error {
 		return err
 	}
 
-	if !bldr.skipBuildPrep {
+	if bldr.doBuildPrep {
 		bldr.setupStageErrPrefix("build-prep")
 		if err := bldr.build(true); err != nil {
 			return err
@@ -588,7 +588,7 @@ func CreateSrpm(repo string, pkg string, extraArgs CreateSrpmExtraCmdlineArgs, e
 		bldr := srpmBuilder{
 			pkgSpec:       &pkgSpec,
 			repo:          repo,
-			skipBuildPrep: extraArgs.SkipBuildPrep,
+			doBuildPrep:   extraArgs.DoBuildPrep,
 			errPrefixBase: errPrefixBase,
 			srcConfig:     srcConfig,
 			executor:      executor,

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -52,7 +52,7 @@ type Multilib struct {
 // the command name(mock/create-srpm) and the value is a list of extra-options.
 //
 //	Valid options for mock are [ --nocheck ]
-//	Valid options for create-srpm are [ --skip-build-prep ]
+//	Valid options for create-srpm are [ --do-build-prep ]
 //
 // MultiLib specifies MultiLib spec to generate multilib. It's indexed by native-arch (i686/x86_64).
 //

--- a/manifest/testData/sampleManifest1.yaml
+++ b/manifest/testData/sampleManifest1.yaml
@@ -43,7 +43,7 @@ package:
           mock:
             - "--nocheck"
           create-srpm:
-            - "--skip-build-prep"
+            - "--do-build-prep"
         external-dependencies:
           glibc: code.arista.io/eos/eext/glibc
   - name: binutils


### PR DESCRIPTION
Deprecated the "--skip-build-prep" option, making it a no-op, and build-prep is now skipped by default. The option "--do-build-prep" has been added for users wanting previous behavior. We cannot remove the option altogether because there're packages which make use of this flag via eextgen.

The motivation is that users have been stumped by %prep failures because of missing dependencies in the their environment. It's not obvious that --skip-build-prep will workaround the problem.

*This is same as this PR: https://github.com/aristanetworks/eos-external-tools/pull/160
But github wrongly says that cannot be rebased.