### PR TITLE
Refactor CheckPath util function.

### DIFF
--- a/impl/create_srpm_from_git.go
+++ b/impl/create_srpm_from_git.go
@@ -184,12 +184,7 @@ func (bldr *srpmBuilder) getUpstreamSourceForGit(upstreamSrcFromManifest manifes
 			return nil, fmt.Errorf("%sexpected public-key for %s to verify git repo",
 				bldr.errPrefix, pkg)
 		}
-		pubKeyPath := filepath.Join(getDetachedSigDir(), pubKey)
-		if pathErr := util.CheckPath(pubKeyPath, false, false); pathErr != nil {
-			return nil, fmt.Errorf("%sCannot find public-key at path %s",
-				bldr.errPrefix, pubKeyPath)
-		}
-		upstreamSrc.pubKeyPath = pubKeyPath
+		upstreamSrc.pubKeyPath = filepath.Join(getDetachedSigDir(), pubKey)
 	}
 
 	return &upstreamSrc, nil

--- a/impl/create_srpm_from_git_test.go
+++ b/impl/create_srpm_from_git_test.go
@@ -215,7 +215,7 @@ func TestGitArchive(t *testing.T) {
 	}
 
 	archivePath := filepath.Join(testWorkingDir, archiveFile)
-	err = util.CheckPath(archivePath, false, false)
+	_, err = os.Stat(archivePath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/impl/create_srpm_from_others.go
+++ b/impl/create_srpm_from_others.go
@@ -89,12 +89,7 @@ func (bldr *srpmBuilder) getUpstreamSourceForOthers(upstreamSrcFromManifest mani
 			return nil, downloadErr
 		}
 
-		pubKeyPath := filepath.Join(getDetachedSigDir(), pubKey)
-		if pathErr := util.CheckPath(pubKeyPath, false, false); pathErr != nil {
-			return nil, fmt.Errorf("%sCannot find public-key at path %s",
-				bldr.errPrefix, pubKeyPath)
-		}
-		upstreamSrc.pubKeyPath = pubKeyPath
+		upstreamSrc.pubKeyPath = filepath.Join(getDetachedSigDir(), pubKey)
 	} else if upstreamSrcType == "srpm" || upstreamSrcType == "unmodified-srpm" {
 		// We don't expect SRPMs to have detached signature or
 		// to be validated with a public-key specified in manifest.

--- a/impl/mock.go
+++ b/impl/mock.go
@@ -102,11 +102,6 @@ func (bldr *mockBuilder) setupDeps() error {
 	}
 	depsDir := viper.GetString("DepsDir")
 
-	// See if depsDir exists
-	if err := util.CheckPath(depsDir, true, false); err != nil {
-		return fmt.Errorf("%sProblem with DepsDir: %s", bldr.errPrefix, err)
-	}
-
 	var missingDeps []string
 	pathMap := make(map[string]string)
 	mockDepsDir := getMockDepsDir(bldr.pkg, bldr.arch)
@@ -114,18 +109,16 @@ func (bldr *mockBuilder) setupDeps() error {
 		depStatisfied := false
 		for _, arch := range []string{"noarch", bldr.arch} {
 			depDirWithArch := filepath.Join(depsDir, arch, dep)
-			if util.CheckPath(depDirWithArch, true, false) == nil {
-				rpmFileGlob := fmt.Sprintf("*.%s.rpm", arch)
-				pathGlob := filepath.Join(depDirWithArch, rpmFileGlob)
-				paths, globErr := filepath.Glob(pathGlob)
-				if globErr != nil {
-					panic(fmt.Sprintf("Bad glob pattern %s: %s", pathGlob, globErr))
-				}
-				if paths != nil {
-					depStatisfied = true
-					copyDestDir := filepath.Join(mockDepsDir, arch, dep)
-					pathMap[copyDestDir] = pathGlob
-				}
+			rpmFileGlob := fmt.Sprintf("*.%s.rpm", arch)
+			pathGlob := filepath.Join(depDirWithArch, rpmFileGlob)
+			paths, globErr := filepath.Glob(pathGlob)
+			if globErr != nil {
+				panic(fmt.Sprintf("Bad glob pattern %s: %s", pathGlob, globErr))
+			}
+			if paths != nil {
+				depStatisfied = true
+				copyDestDir := filepath.Join(mockDepsDir, arch, dep)
+				pathMap[copyDestDir] = pathGlob
 			}
 		}
 		if !depStatisfied {

--- a/impl/mock_cfg.go
+++ b/impl/mock_cfg.go
@@ -147,10 +147,6 @@ func (cfgBldr *mockCfgBuilder) prep() error {
 	for _, includeFile := range cfgBldr.buildSpec.Include {
 		pkgDirInRepo := getPkgDirInRepo(cfgBldr.repo, cfgBldr.pkg, cfgBldr.isPkgSubdirInRepo)
 		includeFilePath := filepath.Join(pkgDirInRepo, includeFile)
-		if err := util.CheckPath(includeFilePath, false, false); err != nil {
-			return fmt.Errorf("%sinclude file %s not found in repo",
-				cfgBldr.errPrefix, pkgDirInRepo)
-		}
 		if err := util.CopyToDestDir(
 			includeFilePath, mockCfgDir, cfgBldr.errPrefix); err != nil {
 			return err

--- a/util/util.go
+++ b/util/util.go
@@ -14,7 +14,6 @@ import (
 
 	"code.arista.io/eos/tools/eext/executor"
 	"github.com/spf13/viper"
-	"golang.org/x/sys/unix"
 )
 
 // Globals type struct exported for global flags
@@ -74,23 +73,6 @@ func CheckOutput(name string, arg ...string) (
 	return string(output), nil
 }
 
-// CheckPath checks if path exists. It also optionally checks if it is a directory,
-// or if the path is writable
-func CheckPath(path string, checkDir bool, checkWritable bool) error {
-	info, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if checkDir && !info.IsDir() {
-		return fmt.Errorf("%s is not a directory", path)
-	}
-
-	if checkWritable && unix.Access(path, unix.W_OK) != nil {
-		return fmt.Errorf("%s is not writable", path)
-	}
-	return nil
-}
-
 // MaybeCreateDirWithParents creates a directory at dirPath if one
 // doesn't already exist. It also creates any parent directories.
 func MaybeCreateDirWithParents(dirPath string, executor executor.Executor, errPrefix ErrPrefix) error {
@@ -118,11 +100,6 @@ func CopyToDestDir(
 	srcGlob string,
 	destDir string,
 	errPrefix ErrPrefix) error {
-
-	if err := CheckPath(destDir, true, true); err != nil {
-		return fmt.Errorf("%sDirectory %s should be present and writable: %s",
-			errPrefix, destDir, err)
-	}
 
 	filesToCopy, patternErr := filepath.Glob(srcGlob)
 	if patternErr != nil {


### PR DESCRIPTION
CheckPath function from utils/util.go gives a false sense of security, that the checked path exists, but this is susceptible to race conditions (where a path may already be gone as soon as this function returns). The functions using the CheckPath function after using it call things that may also return error, making the Check redundant. 
Hence function, and the call is being removed.

 Fixes: BUG1064014
