### PR TITLE
Replaced direct os calls for mkdir with executor

### DIFF
--- a/impl/common.go
+++ b/impl/common.go
@@ -256,12 +256,12 @@ func download(srcURL string, targetDir string,
 // We walk through all the entries of pathMap and then copy files matching
 // the glob to the the corresponding destDirPath.
 // Note that we make sure destDirPath is created with parents before copying.
-func filterAndCopy(pathMap map[string]string, errPrefix util.ErrPrefix) error {
+func filterAndCopy(pathMap map[string]string, executor executor.Executor, errPrefix util.ErrPrefix) error {
 	for destDirPath, srcGlob := range pathMap {
 		// Don't create arch directory unless there's RPMs to be copied.
 		filesToCopy, _ := filepath.Glob(srcGlob)
 		if filesToCopy != nil {
-			if err := util.MaybeCreateDirWithParents(destDirPath, errPrefix); err != nil {
+			if err := util.MaybeCreateDirWithParents(destDirPath, executor, errPrefix); err != nil {
 				return err
 			}
 			if err := util.CopyToDestDir(srcGlob, destDirPath, errPrefix); err != nil {

--- a/impl/create_srpm.go
+++ b/impl/create_srpm.go
@@ -84,7 +84,7 @@ func (bldr *srpmBuilder) fetchUpstream() error {
 	// First fetch upstream source
 	downloadDir := getDownloadDir(bldr.pkgSpec.Name)
 
-	if err := util.MaybeCreateDirWithParents(downloadDir, bldr.errPrefix); err != nil {
+	if err := util.MaybeCreateDirWithParents(downloadDir, bldr.executor, bldr.errPrefix); err != nil {
 		return err
 	}
 
@@ -247,7 +247,7 @@ func (bldr *srpmBuilder) setupRpmbuildTreeNonSrpm() error {
 	// Now copy tarball upstream sources to SOURCES
 	rpmbuildDir := getRpmbuildDir(bldr.pkgSpec.Name)
 	rpmbuildSourcesDir := filepath.Join(rpmbuildDir, "SOURCES")
-	if err := util.MaybeCreateDirWithParents(rpmbuildSourcesDir, bldr.errPrefix); err != nil {
+	if err := util.MaybeCreateDirWithParents(rpmbuildSourcesDir, bldr.executor, bldr.errPrefix); err != nil {
 		return err
 	}
 
@@ -264,7 +264,7 @@ func (bldr *srpmBuilder) setupRpmbuildTreeNonSrpm() error {
 	}
 
 	rpmbuildSpecsDir := filepath.Join(rpmbuildDir, "SPECS")
-	if err := util.MaybeCreateDirWithParents(rpmbuildSpecsDir, bldr.errPrefix); err != nil {
+	if err := util.MaybeCreateDirWithParents(rpmbuildSpecsDir, bldr.executor, bldr.errPrefix); err != nil {
 		return err
 	}
 
@@ -487,7 +487,7 @@ func (bldr *srpmBuilder) copyResultsToDestDir() error {
 
 	pkgSrpmsDestDir := getPkgSrpmsDestDir(bldr.pkgSpec.Name)
 	if err := util.MaybeCreateDirWithParents(
-		pkgSrpmsDestDir, bldr.errPrefix); err != nil {
+		pkgSrpmsDestDir, bldr.executor, bldr.errPrefix); err != nil {
 		return err
 	}
 

--- a/impl/mock.go
+++ b/impl/mock.go
@@ -138,7 +138,7 @@ func (bldr *mockBuilder) setupDeps() error {
 			bldr.errPrefix, strings.Join(missingDeps, ","), depsDir)
 	}
 
-	if copyErr := filterAndCopy(pathMap, bldr.errPrefix); copyErr != nil {
+	if copyErr := filterAndCopy(pathMap, bldr.executor, bldr.errPrefix); copyErr != nil {
 		return copyErr
 	}
 	createRepoErr := bldr.executor.Exec("createrepo", mockDepsDir)
@@ -270,7 +270,7 @@ func (bldr *mockBuilder) copyResultsToDestDir() error {
 			fmt.Sprintf("*.%s.rpm", rpmArch))
 		pathMap[pkgRpmsDestDirForArch] = globPattern
 	}
-	copyErr := filterAndCopy(pathMap, bldr.errPrefix)
+	copyErr := filterAndCopy(pathMap, bldr.executor, bldr.errPrefix)
 	if copyErr != nil {
 		return copyErr
 	}

--- a/impl/mock_cfg.go
+++ b/impl/mock_cfg.go
@@ -120,7 +120,7 @@ func (cfgBldr *mockCfgBuilder) populateTemplateData() error {
 	}
 
 	mockCfgDir := getMockCfgDir(pkg, arch)
-	if err := util.MaybeCreateDirWithParents(mockCfgDir, cfgBldr.errPrefix); err != nil {
+	if err := util.MaybeCreateDirWithParents(mockCfgDir, cfgBldr.executor, cfgBldr.errPrefix); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (cfgBldr *mockCfgBuilder) populateTemplateData() error {
 func (cfgBldr *mockCfgBuilder) prep() error {
 	arch := cfgBldr.arch
 	mockCfgDir := getMockCfgDir(cfgBldr.pkg, arch)
-	if err := util.MaybeCreateDirWithParents(mockCfgDir, cfgBldr.errPrefix); err != nil {
+	if err := util.MaybeCreateDirWithParents(mockCfgDir, cfgBldr.executor, cfgBldr.errPrefix); err != nil {
 		return err
 	}
 

--- a/impl/mock_cfg_test.go
+++ b/impl/mock_cfg_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"code.arista.io/eos/tools/eext/dnfconfig"
+	"code.arista.io/eos/tools/eext/executor"
 	"code.arista.io/eos/tools/eext/manifest"
 	"code.arista.io/eos/tools/eext/testutil"
 	"code.arista.io/eos/tools/eext/util"
@@ -83,6 +84,7 @@ func testMockConfig(t *testing.T, chained bool) {
 			buildSpec:       &manifestObj.Package[0].Build,
 			dnfConfig:       dnfConfig,
 			dependencyList:  dependencyList,
+			executor:        &executor.OsExecutor{},
 		},
 	}
 

--- a/util/util.go
+++ b/util/util.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"code.arista.io/eos/tools/eext/executor"
 	"github.com/spf13/viper"
 	"golang.org/x/sys/unix"
 )
@@ -90,20 +91,10 @@ func CheckPath(path string, checkDir bool, checkWritable bool) error {
 	return nil
 }
 
-// MaybeCreateDir creates a directory with permissions 0775
-// Pre-existing directories are left untouched.
-func MaybeCreateDir(dirPath string, errPrefix ErrPrefix) error {
-	err := os.Mkdir(dirPath, 0775)
-	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("%s: Error '%s' creating %s", errPrefix, err, dirPath)
-	}
-	return nil
-}
-
 // MaybeCreateDirWithParents creates a directory at dirPath if one
 // doesn't already exist. It also creates any parent directories.
-func MaybeCreateDirWithParents(dirPath string, errPrefix ErrPrefix) error {
-	if err := RunSystemCmd("mkdir", "-p", dirPath); err != nil {
+func MaybeCreateDirWithParents(dirPath string, executor executor.Executor, errPrefix ErrPrefix) error {
+	if err := executor.Exec("mkdir", "-p", dirPath); err != nil {
 		return fmt.Errorf("%sError '%s' trying to create directory %s with parents",
 			errPrefix, err, dirPath)
 	}


### PR DESCRIPTION
Replaced direct os call for mkdir with executor in MaybeCreateDirWithParents.
During a dry run, the executor will log dir creation instead of creating it.
Removed definition of MaybeCreateDir from util/util.go

Fixes: BUG1064009
Fixes: BUG1064011